### PR TITLE
Fixed php notice AddLoadersPass

### DIFF
--- a/DependencyInjection/Compiler/AddLoadersPass.php
+++ b/DependencyInjection/Compiler/AddLoadersPass.php
@@ -32,7 +32,9 @@ class AddLoadersPass implements CompilerPassInterface
 
     protected function registerLoader($loaderId)
     {
-        $id = end(explode('.', $loaderId));
+        $split = explode('.', $loaderId);
+        $id    = end($split);
+
         $this->container
             ->getDefinition('bazinga.exposetranslation.controller')
             ->addMethodCall('addLoader', array($id, new Reference($loaderId)));


### PR DESCRIPTION
Runtime Notice: Only variables should be passed by reference in /path/to/vend
or/bundles/Bazinga/ExposeTranslationBundle/DependencyInjection/Compiler/AddLoadersPass.php line 35
