### PR TITLE
Fix invalid getExtension() call on \SplFileInfo

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -77,8 +77,10 @@ class Controller
 
         $catalogues = array();
         foreach ($files as $file) {
-            if (isset($this->loaders[$file->getExtension()])) {
-                $catalogues[] = $this->loaders[$file->getExtension()]->load($file, $_locale, $domain_name);
+            $extension = pathinfo($file->getFilename(), \PATHINFO_EXTENSION);
+
+            if (isset($this->loaders[$extension])) {
+                $catalogues[] = $this->loaders[$extension]->load($file, $_locale, $domain_name);
             }
         }
 


### PR DESCRIPTION
Fatal error:  Call to undefined method Symfony\Component\Finder\SplFileInfo::getExtension() in /path/to/vendor/bundles/Bazinga/ExposeTranslationBundle/Controller/Controller.php on line 80
