### PR TITLE
Fix js code for default domains

### DIFF
--- a/Resources/views/exposeTranslation.js.twig
+++ b/Resources/views/exposeTranslation.js.twig
@@ -1,5 +1,5 @@
 $.ExposeTranslation.locale = '{{ locale }}';
-$.ExposeTranslation.defaultDomains = [{% for domain in defaultDomains %}{{ domain }},{% endfor %}];
+$.ExposeTranslation.defaultDomains = [{% if defaultDomains %}"{{ defaultDomains|join('", "')|raw }}"{% endif %}];
 {% for domain, translations in messages %}
 {% for key, message in translations %}
 $.ExposeTranslation.add({{ (domain~":"~key)|json_encode|raw }}, {{ message|json_encode|raw }});


### PR DESCRIPTION
Surround domains with quotes and remove trailing comma.

Old output:

```
$.ExposeTranslation.defaultDomains = [messages,];
```

New output:

```
$.ExposeTranslation.defaultDomains = ["messages"];
```
