### PR TITLE
Fixed forget the variable declaration

### DIFF
--- a/Resources/public/js/translation.js
+++ b/Resources/public/js/translation.js
@@ -6,7 +6,7 @@
 /**
  * Define Translation class.
  */
-ExposeTranslation = ExposeTranslation || {};
+var ExposeTranslation = ExposeTranslation || {};
 
 (function(Translation, $, undefined) {
   // now register our routing methods


### PR DESCRIPTION
Forget the 'var' to declare the variable ExposeTranslation inside the js file.
