### PR TITLE
Fixed the composer constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     }
   ],
   "require": {
-    "symfony/framework-bundle": "2.*"
+    "symfony/framework-bundle": ">=2.0,<2.2-dev",
+    "symfony/finder": ">=2.0,<2.2-dev"
   },
   "autoload": {
     "psr-0": { "Bazinga\\ExposeTranslationBundle": "" }


### PR DESCRIPTION
This fixes the upper bound for the FrameworkBundle requirement (I doubt you know the plans for all future 2.x releases as even Fabien does not) and adds the missing dependency on the finder (which is only suggested by FrameworkBundle)
