### PR TITLE
Fixed the cache handling.

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -90,7 +90,7 @@ class Controller
      */
     public function exposeTranslationAction(Request $request, $domain_name, $_locale, $_format)
     {
-        $cache = new ConfigCache($this->cacheDir.'/bazingaExposeTranslation.'.$_locale.".".$_format, $this->debug);
+        $cache = new ConfigCache($this->cacheDir.'/'.$domain_name.'.'.$_locale.".".$_format, $this->debug);
 
         if (!$cache->isFresh()) {
             $files = $this->translationFinder->getResources($domain_name, $_locale);

--- a/Resources/config/controllers.xml
+++ b/Resources/config/controllers.xml
@@ -12,7 +12,7 @@
             <argument type="service" id="translator" />
             <argument type="service" id="templating" />
             <argument type="service" id="bazinga.exposetranslation.service.translation_finder" />
-            <argument>%kernel.cache_dir%</argument>
+            <argument>%kernel.cache_dir%/bazinga_expose_translation</argument>
             <argument>%kernel.debug%</argument>
             <argument></argument>
         </service>


### PR DESCRIPTION
A different cache file must be used for each domain, otherwise the
data will be wrong when loading a second domain.

To avoid cluttering the root cache folder with many `bazingaExposeTranslation.*` files (2 files per domain per locale), I moved all cache files in a subfolder
