### PR TITLE
Add support to xlf without losing xliff support

### DIFF
--- a/DependencyInjection/Compiler/AddLoadersPass.php
+++ b/DependencyInjection/Compiler/AddLoadersPass.php
@@ -22,17 +22,20 @@ class AddLoadersPass implements CompilerPassInterface
         $this->container = $container;
 
         foreach ($container->findTaggedServiceIds('translation.loader') as $loaderId => $attributes) {
-            $this->registerLoader($loaderId);
+            $attributes = array_shift($attributes);
+
+            $this->registerLoader($attributes['alias'], $loaderId);
+
+            if (isset($attributes['legacy-alias'])) {
+                $this->registerLoader($attributes['legacy-alias'], $loaderId);
+            }
         }
     }
 
-    protected function registerLoader($loaderId)
+    protected function registerLoader($alias, $loaderId)
     {
-        $split = explode('.', $loaderId);
-        $id    = end($split);
-
         $this->container
             ->getDefinition('bazinga.exposetranslation.controller')
-            ->addMethodCall('addLoader', array($id, new Reference($loaderId)));
+            ->addMethodCall('addLoader', array($alias, new Reference($loaderId)));
     }
 }


### PR DESCRIPTION
Since Symfony changed the extension of translation files from `xliff` to `xlf` the bundle is **not** rendering all messages for the domain.

Using `translation.xml` as base for this commit:

```
<service id="translation.loader.xliff" class="%translation.loader.xliff.class%">
    <tag name="translation.loader" alias="xlf" legacy-alias="xliff" />
</service>
```

I've updated the `AddLoaderPass.php` to use the attributes available instead of guessing the extension.

Related to #36
