### PR TITLE
Removes duplicates from dumped translation messages

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -119,11 +119,7 @@ class Controller
 
             $messages = array();
             foreach ($catalogues as $catalogue) {
-                $messages = array_merge_recursive($messages, $catalogue->all());
-            }
-
-            foreach ($messages as &$domain) {
-                $domain = array_map(function($m){ return is_array($m) ? end($m) : $m; }, $domain);
+                $messages = array_replace_recursive($messages, $catalogue->all());
             }
 
             $content = $this->engine->render('BazingaExposeTranslationBundle::exposeTranslation.' . $_format . '.twig', array(

--- a/Dumper/TranslationDumper.php
+++ b/Dumper/TranslationDumper.php
@@ -101,8 +101,6 @@ class TranslationDumper
         foreach ($this->getTranslationMessages() as $locale => $domains) {
             foreach ($domains as $domain => $messageList) {
                 foreach ($formats as $format) {
-                    $messageList = array_map(function($m){ return is_array($m) ? end($m) : $m; }, $messageList);
-
                     $content = $this->engine->render('BazingaExposeTranslationBundle::exposeTranslation.' . $format . '.twig', array(
                         'messages'        => array($domain => $messageList),
                         'locale'          => $locale,
@@ -160,7 +158,7 @@ class TranslationDumper
                 $catalogue = $this->loaders[$extension]->load($file, $locale, $domain);
 
                 if (isset($messages[$locale])) {
-                    $messages[$locale] = array_merge_recursive($messages[$locale], $catalogue->all());
+                    $messages[$locale] = array_replace_recursive($messages[$locale], $catalogue->all());
                 } else {
                     $messages[$locale] = $catalogue->all();
                 }


### PR DESCRIPTION
`array_merge_recursive` combines values of duplicate array keys into arrays (`array_merge_recursive(array('test' => 1), array('test' => 2))` becomes `array('test' => array(1, 2))` which causes duplicate translation messages. This fix is copied from the controller which fixes the same issue.
