### PR TITLE
[feature] Changed scope of getTranslationMessages to protected

### DIFF
--- a/Dumper/TranslationDumper.php
+++ b/Dumper/TranslationDumper.php
@@ -139,7 +139,7 @@ class TranslationDumper
      *
      * @return array
      */
-    private function getTranslationMessages()
+    protected function getTranslationMessages()
     {
         $messages = array();
 


### PR DESCRIPTION
I changed the scope of the function getTranslationMessages to protected.
# Scenario

I don't want to dump all my translation files/domains to the web/js directory. I've created my own _TranslationDumper_ class that inherits from _Bazinga\ExposeTranslationBundle\Dumper\TranslationDumper_. 
I would like to override the _getTranslationMessages()_ only so I can benefit form possible future bugfixes/features in the rest of the _Bazinga\ExposeTranslationBundle\Dumper\TranslationDumper_-class.
