### PR TITLE
js dump not possible if i18n for route is enabled

### DIFF
--- a/Resources/config/routing/routing.yml
+++ b/Resources/config/routing/routing.yml
@@ -1,5 +1,6 @@
 bazinga_exposetranslation_js:
     pattern:  /i18n/{domain_name}/{_locale}.{_format}
     defaults: { _controller: bazinga.exposetranslation.controller:exposeTranslationAction, domain_name: "messages", _format: "js" }
+    options: {"i18n": false}
     requirements:
         _format: js|json


### PR DESCRIPTION
It is not possible to dump the translation is the i18n for routes is enabled.
I try the command: php app/console bazinga:expose-translation:dump
and i got the error: 
Fatal error: Call to a member function getRequirements() on a non-object in /vendor/willdurand/expose-translation-bundle/Bazinga/ExposeTranslationBundle/Dumper/TranslationDumper.php on line 92
This route is technical and should not be i18n.
