### PR TITLE
Bundle configuration normalization error fixed

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,7 +20,6 @@ class Configuration implements ConfigurationInterface
         $builder = new TreeBuilder();
 
         $builder->root('bazinga_js_translation')
-            ->fixXmlConfig('default_domain')
             ->children()
                 ->scalarNode('locale_fallback')->defaultValue('en')->end()
                 ->scalarNode('default_domain')->defaultValue('messages')->end()


### PR DESCRIPTION
Xml pluralization is not needed as `default_domain` is now a scalar node instead of an array.

Having it will throw an InvalidConfigurationException (only if value is configured)

---

I didn't want to open a new issue for this but I'm wondering: 
Why rename the bundle instead of creating another repo? I don't want to sound critical or anything but wouldn't this have given others more time to update their applications accordingly?
