### PR TITLE
Fixes symfony 2.1 incompatibility

### DIFF
--- a/Finder/TranslationFinder.php
+++ b/Finder/TranslationFinder.php
@@ -109,9 +109,9 @@ class TranslationFinder
 
             if (file_exists($dir = dirname($r->getFilename()).'/../../Resources/translations')) {
                 $locations[] = $dir;
-            } else {
+            } elseif (file_exists($dir = dirname($r->getFilename()).'/../Resources/translations')) {
                 // Symfony 2.4 and above
-                $locations[] = dirname($r->getFilename()).'/../Resources/translations';
+                $locations[] = $dir;
             }
         }
 


### PR DESCRIPTION
Translations has been introduced in symfony security component in
symfony 2.2 (symfony/symfony@963a1d7b81b4c083d031b629a8bfb933fdf6eea8)

Fixes #90
