### PR TITLE
Add documentation for AngularJS integration

### DIFF
--- a/Resources/doc/angular-integration.md
+++ b/Resources/doc/angular-integration.md
@@ -1,0 +1,10 @@
+# AngularJS integration
+
+If you're using AngularJS in conjunction with your Symfony app and need
+to expose your translations to it, you can do so by using the [Angular
+Symfony Translation
+module](https://github.com/boxuk/angular-symfony-translation).
+
+Further documentation for using this module is available at the above
+link.
+


### PR DESCRIPTION
Adds documentation for integrating this bundle with AngularJS (using the Angular module available at: https://github.com/boxuk/angular-symfony-translation).

I've tried to keep this as concise as possible and to avoid duplicating documentation between this repository and the Angular module, though I can add more detail if you think it would be beneficial.
