### PR TITLE
Don’t make the fallback locale the only one active

### DIFF
--- a/DependencyInjection/BazingaJsTranslationExtension.php
+++ b/DependencyInjection/BazingaJsTranslationExtension.php
@@ -31,8 +31,8 @@ class BazingaJsTranslationExtension extends Extension
             ->replaceArgument(5, $config['locale_fallback'])
             ->replaceArgument(6, $config['default_domain']);
 
-        // Add fallback local to active locales if miss
-        if (!in_array($config['locale_fallback'], $config['active_locales'])) {
+        // Add fallback locale to active locales if missing
+        if ($config['active_locales'] && !in_array($config['locale_fallback'], $config['active_locales'])) {
             array_push($config['active_locales'], $config['locale_fallback']);
         }
 


### PR DESCRIPTION
If every locale is implicitly active (`$config['active_locales']` is empty) the fallback locale doesn’t need to be added. Even worse, it populates the active_locales list and thus deactivates the other locales.

So: Only add it if it’s really missing.
