### PR TITLE
Replaced routing deprecated arguments

### DIFF
--- a/Resources/config/routing/routing.yml
+++ b/Resources/config/routing/routing.yml
@@ -1,5 +1,5 @@
 bazinga_jstranslation_js:
-    pattern:  /translations/{domain}.{_format}
+    path:  /translations/{domain}.{_format}
     defaults: { _controller: bazinga.jstranslation.controller:getTranslationsAction, domain: "messages", _format: "js" }
     methods:  [ GET ]
     options:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Replaced arguments that are deprecated from Symfony 2.2.

**Before**:
```yaml
bazinga_jstranslation_js:
    pattern:  /translations/{domain}.{_format}
```

**After**:
```yaml
bazinga_jstranslation_js:
    path:  /translations/{domain}.{_format}
```