### PR TITLE
Add /js as routing prefix

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -38,6 +38,7 @@ Register the routing in `app/config/routing.yml`:
 # app/config/routing.yml
 _bazinga_jstranslation:
     resource: "@BazingaJsTranslationBundle/Resources/config/routing/routing.yml"
+    prefix: /js
 ```
 
 Publish assets:


### PR DESCRIPTION
... so controller will take over if translation assets are not dumped yet. That way the url is consistent with the Assetic configuration.

Or maybe the Assetic and the dump path should be changed?
