### PR TITLE
Replace Validator classname with Validation to omit deprecated warning

### DIFF
--- a/Finder/TranslationFinder.php
+++ b/Finder/TranslationFinder.php
@@ -69,8 +69,8 @@ class TranslationFinder
     {
         $locations = array();
 
-        if (class_exists('Symfony\Component\Validator\Validator')) {
-            $r = new \ReflectionClass('Symfony\Component\Validator\Validator');
+        if (class_exists('Symfony\Component\Validator\Validation')) {
+            $r = new \ReflectionClass('Symfony\Component\Validator\Validation');
 
             $locations[] = dirname($r->getFilename()).'/Resources/translations';
         }


### PR DESCRIPTION
With release of Symfony 2.7 deprecated warnings were added:

DEPRECATED - The Symfony\Component\Validator\Validator class is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\Validator\Validator\RecursiveValidator class instead.

See https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Validator/Validator.php#L14
This PR fixes warning when referring to deprecated classname.