### PR TITLE
Replace string casting on ConfigCache instance with getPath() to omit…

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -164,10 +164,16 @@ class Controller
             }
         }
 
+        if (method_exists($cache, 'getPath')) {
+            $cachePath = $cache->getPath();
+        } else {
+            $cachePath = (string) $cache;
+        }
+
         $expirationTime = new \DateTime();
         $expirationTime->modify('+' . $this->httpCacheTime . ' seconds');
         $response = new Response(
-            file_get_contents((string) $cache),
+            file_get_contents($cachePath),
             200,
             array('Content-Type' => $request->getMimeType($_format))
         );


### PR DESCRIPTION


With release of Symfony 2.7 deprecated warnings were added:

DEPRECATED - ConfigCache::__toString() is deprecated since version 2.7 and will be removed in 3.0. Use the getPath() method instead.

See https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Config/ConfigCache.php#L49
This PR fixes warning when casting instance of ConfigCache to string.
