### PR TITLE
Safer twig locale

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -58,7 +58,7 @@ Then add the current application's locale into your layout, by adding a `lang`
 attribute to the `html` tag:
 
 ```html
-<html lang="{{ app.request.locale }}">
+<html lang="{{ app.request.locale|split('_')[0] }}">
 ```
 
 Now, you are done with the basic setup, and you can specify the [translation


### PR DESCRIPTION
The recommended way of storing locales is language code underscore country code, e.g. en_GB.

> The term locale refers roughly to the user's language and country. It can be any string that your application uses to manage translations and other format differences (e.g. currency format). The ISO 639-1 language code, an underscore (_), then the ISO 3166-1 alpha-2 country code (e.g. fr_FR for French/France) is recommended.
> – http://symfony.com/doc/current/book/translation.html

Therefore, a safe way of using the locale in the lang attribute would be:

```twig
<html lang="{{ app.request.locale|split('_')[0] }}">
```

This works with both an **en_GB** locale and an **en** locale.

Source: http://stackoverflow.com/a/30538515/2106834