### PR TITLE
Use framework bundle translation files paths

### DIFF
--- a/BazingaJsTranslationBundle.php
+++ b/BazingaJsTranslationBundle.php
@@ -2,6 +2,7 @@
 
 namespace Bazinga\Bundle\JsTranslationBundle;
 
+use Bazinga\Bundle\JsTranslationBundle\DependencyInjection\Compiler\TranslationResourceFilesPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Bazinga\Bundle\JsTranslationBundle\DependencyInjection\Compiler\AddLoadersPass;
@@ -16,5 +17,6 @@ class BazingaJsTranslationBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new AddLoadersPass());
+        $container->addCompilerPass(new TranslationResourceFilesPass());
     }
 }

--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -134,13 +134,13 @@ class Controller
 
                 $translations[$locale][$domain] = array();
 
-                foreach ($files as $file) {
-                    $extension = pathinfo($file->getFilename(), \PATHINFO_EXTENSION);
+                foreach ($files as $filename) {
+                    $extension = pathinfo($filename, \PATHINFO_EXTENSION);
 
                     if (isset($this->loaders[$extension])) {
-                        $resources[] = new FileResource($file->getPath());
+                        $resources[] = new FileResource($filename);
                         $catalogue   = $this->loaders[$extension]
-                            ->load($file, $locale, $domain);
+                            ->load($filename, $locale, $domain);
 
                         $translations[$locale][$domain] = array_replace_recursive(
                             $translations[$locale][$domain],

--- a/DependencyInjection/Compiler/TranslationResourceFilesPass.php
+++ b/DependencyInjection/Compiler/TranslationResourceFilesPass.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Bazinga\Bundle\JsTranslationBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * @author Hugo MONTEIRO <hugo.monteiro@gmail.com>
+ */
+class TranslationResourceFilesPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('translator.default')) {
+            return;
+        }
+
+        if (Kernel::VERSION_ID < 20700) {
+            $translationFiles = $this->getTranslationFilesFromOlderSymfonyVersions($container);
+        } else {
+            $translationFiles = $this->getTranslationFiles($container);
+        }
+
+        $container->getDefinition('bazinga.jstranslation.translation_finder')->replaceArgument(0, $translationFiles);
+    }
+
+    private function getTranslationFilesFromOlderSymfonyVersions(ContainerBuilder $container)
+    {
+        $translationFiles = array();
+
+        $methodCalls = $container->getDefinition('translator.default')->getMethodCalls();
+        foreach($methodCalls as $methodCall) {
+            if ($methodCall[0] === 'addResource') {
+                $locale = $methodCall[1][2];
+                $filename = $methodCall[1][1];
+
+                if (!isset($translationFiles[$locale])) {
+                    $translationFiles[$locale] = array();
+                }
+
+                $translationFiles[$locale][] = $filename;
+            }
+        }
+
+        return $translationFiles;
+    }
+
+    private function getTranslationFiles(ContainerBuilder $container)
+    {
+        $translationFiles = array();
+
+        $translatorOptions = $container->getDefinition('translator.default')->getArgument(3);
+        if (isset($translatorOptions['resource_files'])) {
+            $translationFiles = $translatorOptions['resource_files'];
+        }
+
+        return $translationFiles;
+    }
+}

--- a/Dumper/TranslationDumper.php
+++ b/Dumper/TranslationDumper.php
@@ -202,8 +202,8 @@ class TranslationDumper
         $translations = array();
         $activeLocales = $this->activeLocales;
         $activeDomains = $this->activeDomains;
-        foreach ($this->finder->all() as $file) {
-            list($extension, $locale, $domain) = $this->getFileInfo($file);
+        foreach ($this->finder->all() as $filename) {
+            list($extension, $locale, $domain) = $this->getFileInfo($filename);
 
             if ( (count($activeLocales) > 0 && !in_array($locale, $activeLocales)) || (count($activeDomains) > 0 && !in_array($domain, $activeDomains)) ) {
                 continue;
@@ -219,7 +219,7 @@ class TranslationDumper
 
             if (isset($this->loaders[$extension])) {
                 $catalogue = $this->loaders[$extension]
-                    ->load($file, $locale, $domain);
+                    ->load($filename, $locale, $domain);
 
                 $translations[$locale][$domain] = array_replace_recursive(
                     $translations[$locale][$domain],
@@ -231,17 +231,9 @@ class TranslationDumper
         return $translations;
     }
 
-    private function getFileInfo($file)
+    private function getFileInfo($filename)
     {
-        $filename  = explode('.', $file->getFilename());
-        $extension = end($filename);
-        $locale    = prev($filename);
-
-        $domain = array();
-        while (prev($filename)) {
-            $domain[] = current($filename);
-        }
-        $domain = implode('.', $domain);
+        list($domain, $locale, $extension) = explode('.', basename($filename), 3);
 
         return array($extension, $locale, $domain);
     }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,7 +10,7 @@
 
     <services>
         <service id="bazinga.jstranslation.translation_finder" class="%bazinga.jstranslation.translation_finder.class%">
-            <argument type="service" id="kernel" />
+            <argument type="collection"></argument> <!-- all resource files paths from the framework bundle -->
         </service>
         <service id="bazinga.jstranslation.translation_dumper" class="%bazinga.jstranslation.translation_dumper.class%">
             <argument type="service" id="templating" />

--- a/Tests/Controller/ControllerTest.php
+++ b/Tests/Controller/ControllerTest.php
@@ -3,6 +3,7 @@
 namespace Bazinga\JsTranslationBundle\Tests\Controller;
 
 use Bazinga\Bundle\JsTranslationBundle\Tests\WebTestCase;
+use Symfony\Component\HttpKernel\Kernel;
 
 class ControllerTest extends WebTestCase
 {
@@ -280,5 +281,27 @@ JSON
 
 JSON
         , $response->getContent());
+    }
+
+    public function testGetTranslationsOutsideResourcesFolder()
+    {
+        if (Kernel::VERSION_ID < 20800) {
+            return;
+        }
+
+        $client  = static::createClient();
+
+        $crawler  = $client->request('GET', '/translations/outsider.json');
+        $response = $client->getResponse();
+
+        $this->assertEquals(<<<JSON
+{
+    "fallback": "en",
+    "defaultDomain": "messages",
+    "translations": {"en":{"outsider":{"frontpage.hi":"hi"}}}
+}
+
+JSON
+            , $response->getContent());
     }
 }

--- a/Tests/Dumper/TranslationDumperTest.php
+++ b/Tests/Dumper/TranslationDumperTest.php
@@ -17,8 +17,7 @@ class TranslationDumperTest extends WebTestCase
 
     public function setUp()
     {
-        $client    = static::createClient();
-        $container = $client->getContainer();
+        $container = $this->getContainer();
 
         $this->target     = sys_get_temp_dir() . '/bazinga/js-translation-bundle';
         $this->filesystem = $container->get('filesystem');

--- a/Tests/Fixtures/app/AppKernel.php
+++ b/Tests/Fixtures/app/AppKernel.php
@@ -60,7 +60,11 @@ class AppKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load(__DIR__.'/config/'.$this->environment.'.yml');
+        if (self::VERSION_ID < 20800) {
+            $loader->load(__DIR__.'/config/older_versions_config.yml');
+        } else {
+            $loader->load(__DIR__.'/config/'.$this->environment.'.yml');
+        }
     }
 
     public function serialize()

--- a/Tests/Fixtures/app/Infrastructure/Ui/Translations/outsider.en.yml
+++ b/Tests/Fixtures/app/Infrastructure/Ui/Translations/outsider.en.yml
@@ -1,0 +1,1 @@
+frontpage.hi: hi

--- a/Tests/Fixtures/app/config/default.yml
+++ b/Tests/Fixtures/app/config/default.yml
@@ -1,20 +1,8 @@
+imports:
+    - { resource: older_versions_config.yml }
+
 framework:
-    secret:        test
-    router:        { resource: "%kernel.root_dir%/config/routing.yml" }
-    templating:    { engines: [ 'twig' ] }
-    test:          ~
-
-# Twig Configuration
-twig:
-    debug:            "%kernel.debug%"
-    strict_variables: "%kernel.debug%"
-
-# Traduction dans JS
-bazinga_js_translation:
-    active_locales:
-        - fr
-        - en
-    active_domains:
-        - messages
-        - numerics
-        - foo
+    translator:
+        fallbacks: ['en']
+        paths:
+            - "%kernel.root_dir%/Infrastructure/Ui/Translations"

--- a/Tests/Fixtures/app/config/older_versions_config.yml
+++ b/Tests/Fixtures/app/config/older_versions_config.yml
@@ -1,0 +1,21 @@
+framework:
+    secret:        test
+    router:        { resource: "%kernel.root_dir%/config/routing.yml" }
+    templating:    { engines: [ 'twig' ] }
+    test:          ~
+    translator:    { enabled: true }
+
+# Twig Configuration
+twig:
+    debug:            "%kernel.debug%"
+    strict_variables: "%kernel.debug%"
+
+# Traduction dans JS
+bazinga_js_translation:
+    active_locales:
+        - fr
+        - en
+    active_domains:
+        - messages
+        - numerics
+        - foo


### PR DESCRIPTION
I noticed that in the **TranslationFinder** we were fetching by folders all the translations in the system. 
Since the FrameworkBundle already knows which translation is available I thought that we could use it. 

I've created a compiler pass to replace the argument in the **TranslationFinder** with the list of files generated by the **FrameworkBundleExtension**

I have also included a functional test to test if this works.

Closes #160 

Plz review so I can squash later the commits ;) 