### PR TITLE
Add default count parameter on transchoice

### DIFF
--- a/Resources/js/translator.js
+++ b/Resources/js/translator.js
@@ -149,6 +149,11 @@
             );
 
             var _number  = parseInt(number, 10);
+            parameters = parameters || {};
+
+            if (parameters.count === undefined) {
+                parameters.count = number;
+            }
 
             if (typeof _message !== 'undefined' && !isNaN(_number)) {
                 _message = pluralize(
@@ -158,7 +163,7 @@
                 );
             }
 
-            return replace_placeholders(_message, parameters || {});
+            return replace_placeholders(_message, parameters);
         },
 
         /**

--- a/Resources/js/translatorTest.js
+++ b/Resources/js/translatorTest.js
@@ -52,7 +52,7 @@ test('trans()', function() {
 });
 
 test('transChoice()', function() {
-    expect(26);
+    expect(31);
 
     Translator.add('foo.plural', '{0} Nothing|[1,Inf[ Many things', 'Foo');
     Translator.add('foo.plural.with.args', '{0} Nothing|{1} One thing|[2,Inf[ %count% things', 'Foo');
@@ -61,6 +61,9 @@ test('transChoice()', function() {
     Translator.add('foo.plural.space.before.interval', ' {0} Nothing| [1,Inf[ Many things', 'Foo');
     Translator.add('foo.plural.without.space', '{0}Nothing|[1,Inf[Many things', 'Foo');
     Translator.add('foo.single', 'Things', 'Foo');
+    Translator.add('foo.count.parameter', '[0,1]%count% item|]1,Inf[%count% items', 'Foo');
+    Translator.add('foo.count.parameter.additional', '[0,Inf[%count% items of %foo%', 'Foo');
+    Translator.add('foo.count.parameter.overriden', '[0,Inf[%count% items', 'Foo');
 
     // Basic
     equal(Translator.transChoice('foo.plural', null, {}, 'Foo'), '{0} Nothing|[1,Inf[ Many things', 'Returns the correct message for the given key');
@@ -102,6 +105,17 @@ test('transChoice()', function() {
 
     // Message not in a domain with pluralization
     equal(Translator.transChoice('{0} Nothing|[1,Inf[ Many things', 0, {}), 'Nothing', 'number = 0 returns the {0} part of the message');
+
+    // Default count parameter
+    equal(Translator.transChoice('foo.count.parameter', 0, {}, 'Foo'), '0 item', 'number = 0 returns the [0, 1] part of the message');
+    equal(Translator.transChoice('foo.count.parameter', 1, {}, 'Foo'), '1 item', 'number = 1 returns the [0, 1] part of the message');
+    equal(Translator.transChoice('foo.count.parameter', 5, {}, 'Foo'), '5 items', 'number = 5 returns the ]1,Inf[ part of the message');
+
+    // Default count parameter with additional parameters
+    equal(Translator.transChoice('foo.count.parameter.additional', 10, {'foo': 'bar'}, 'Foo'), '10 items of bar', 'number = 10 returns the [0,Inf[ part of the message');
+
+    // Do not override given count parameter
+    equal(Translator.transChoice('foo.count.parameter.overriden', 10, { count: 5 }, 'Foo'), '5 items', 'number = 10 returns the [0,Inf[ part of the message');
 });
 
 test('guesses domains if not specified', function() {


### PR DESCRIPTION
The idea is to have a similar behavior between Symfony translator ([TranslationExtension](https://github.com/symfony/symfony/blob/5129c4cf7e294b1a5ea30d6fec6e89b75396dcd2/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php#L98) and https://github.com/symfony/symfony/pull/19795) and the js translator.