### PR TITLE
Add missing dependencies to composer.json (because Symfony 3.2 framework bundle removed them)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
     - composer install
 
 script:
-    - phpunit --coverage-text
+    - vendor/bin/phpunit --coverage-text
     - phantomjs Resources/js/run-qunit.js file://`pwd`/Resources/js/index.html
     - phantomjs Resources/js/run-qunit.js file://`pwd`/Resources/js/index-with-es5-shim.html
 

--- a/Tests/Fixtures/app/AppKernel.php
+++ b/Tests/Fixtures/app/AppKernel.php
@@ -66,6 +66,10 @@ class AppKernel extends Kernel
         } else {
             $loader->load(__DIR__.'/config/'.$this->environment.'.yml');
         }
+
+        if (self::VERSION_ID > 30200) {
+            $loader->load(__DIR__.'/config/disable_annotations.yml');
+        }
     }
 
     public function serialize()

--- a/Tests/Fixtures/app/config/disable_annotations.yml
+++ b/Tests/Fixtures/app/config/disable_annotations.yml
@@ -1,0 +1,2 @@
+framework:
+    annotations:   { enabled: false }

--- a/Tests/Fixtures/app/config/older_versions_config.yml
+++ b/Tests/Fixtures/app/config/older_versions_config.yml
@@ -4,6 +4,7 @@ framework:
     templating:    { engines: [ 'twig' ] }
     test:          ~
     translator:    { enabled: true }
+    validation:    { enabled: false }
 
 # Twig Configuration
 twig:

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,17 @@
         "symfony/framework-bundle": "~2.7|~3.1",
         "symfony/finder": "~2.7|~3.1",
         "symfony/console": "~2.7|~3.1",
-        "symfony/intl": "~2.7|~3.1"
+        "symfony/intl": "~2.7|~3.1",
+        "symfony/templating": "~2.7|~3.1",
+        "symfony/translation":  "~2.7|~3.1"
     },
     "require-dev": {
+        "symfony/asset": "~2.7|~3.1",
         "symfony/yaml": "~2.7|~3.1",
         "symfony/browser-kit": "~2.7|~3.1",
         "symfony/twig-bundle": "~2.7|~3.1",
-        "symfony/phpunit-bridge": "~2.7|~3.1"
+        "symfony/phpunit-bridge": "~2.7|~3.1",
+        "phpunit/phpunit": "^4.8|~5.7"
     },
     "replace": {
         "willdurand/expose-translation-bundle": "2.5.*"


### PR DESCRIPTION
The new Symfony 3.2 removed some dependencies from framework bundle:
Related: https://github.com/symfony/symfony/pull/20067

Also added phpunit to composer.json because of: https://github.com/sebastianbergmann/phpunit/pull/2264