### PR TITLE
Accept three letters languages

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -195,7 +195,7 @@ class Controller
         }
 
         $locales = array_filter($locales, function ($locale) {
-            return 1 === preg_match('/^[a-z]{2}([-_]{1}[a-zA-Z]{2})?$/', $locale);
+            return 1 === preg_match('/^[a-z]{2,3}([-_]{1}[a-zA-Z]{2})?$/', $locale);
         });
 
         $locales = array_unique(array_map(function ($locale) {

--- a/Tests/Controller/ControllerTest.php
+++ b/Tests/Controller/ControllerTest.php
@@ -325,4 +325,22 @@ JSON
 JSON
             , $response->getContent());
     }
+
+    public function testGetTranslationsWithThreeLettersLocale()
+    {
+        $client  = static::createClient();
+
+        $crawler  = $client->request('GET', '/translations/messages.json?locales=ach_UG');
+        $response = $client->getResponse();
+
+        $this->assertEquals(<<<JSON
+{
+    "fallback": "en",
+    "defaultDomain": "messages",
+    "translations": {"ach_UG":{"messages":{"hello":"hello"}}}
+}
+
+JSON
+            , $response->getContent());
+    }
 }

--- a/Tests/Fixtures/app/Resources/translations/messages.ach_UG.yml
+++ b/Tests/Fixtures/app/Resources/translations/messages.ach_UG.yml
@@ -1,0 +1,1 @@
+hello: hello


### PR DESCRIPTION
A very simple change: it allows three letters language codes.

The use-case I'm facing is crowdin.com, that uses `ach_UG` as a pseudo-language (it's actually "Acholi") for their in-context feature. As the change is really small, and doesn't look harmful to me, I'm proposing it.

I'm experiencing an `Unrecognized option "enabled" under "framework.annotations"` when running the test suite. I would appreciate a hint :-)