### PR TITLE
Remove router dependency from translation dumper.

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -35,7 +35,7 @@ class DumpCommand extends ContainerAwareCommand
             ->addOption(
                 'pattern',
                 null,
-                InputOption::VALUE_REQUIRED,
+                InputOption::VALUE_OPTIONAL,
                 'the route pattern',
                 TranslationDumper::DEFAULT_TRANSLATION_PATTERN
             )

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @author Adrien Russo <adrien.russo.qc@gmail.com>
+ * @author Hugo Monteiro <hugo.monteiro@gmail.com>
  */
 class DumpCommand extends ContainerAwareCommand
 {
@@ -42,6 +43,11 @@ class DumpCommand extends ContainerAwareCommand
                 null,
                 InputOption::VALUE_NONE,
                 'If set, all domains will be merged into a single file per language'
+            )->addOption(
+                'path',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'If set, all the translations are in a different folder (default is "translations")'
             );
     }
 
@@ -81,6 +87,20 @@ class DumpCommand extends ContainerAwareCommand
         $this
             ->getContainer()
             ->get('bazinga.jstranslation.translation_dumper')
-            ->dump($this->targetPath, $formats, $merge);
+            ->dump($this->targetPath, $this->getTranslationsPath($input->getOption('path')), $formats, $merge);
+    }
+
+    /**
+     * Get translations path from the router defined or use the default one.
+     */
+    private function getTranslationsPath($path)
+    {
+        $translationsPathOverriden = empty($path) ? 'translations' : $path;
+        $route = $this->getContainer()->get('router')->getRouteCollection()->get('bazinga_jstranslation_js');
+        if (empty($route)) {
+            return $translationsPathOverriden;
+        }
+
+        return $route->getPath();
     }
 }

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -2,6 +2,7 @@
 
 namespace Bazinga\Bundle\JsTranslationBundle\Command;
 
+use Bazinga\Bundle\JsTranslationBundle\Dumper\TranslationDumper;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -32,6 +33,13 @@ class DumpCommand extends ContainerAwareCommand
             ))
             ->setDescription('Dumps all JS translation files to the filesystem')
             ->addOption(
+                'pattern',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'the route pattern',
+                TranslationDumper::DEFAULT_TRANSLATION_PATTERN
+            )
+            ->addOption(
                 'format',
                 null,
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
@@ -43,11 +51,6 @@ class DumpCommand extends ContainerAwareCommand
                 null,
                 InputOption::VALUE_NONE,
                 'If set, all domains will be merged into a single file per language'
-            )->addOption(
-                'path',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'If set, all the translations are in a different folder (default is "translations")'
             );
     }
 
@@ -68,7 +71,7 @@ class DumpCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $formats = $input->getOption('format');
-        $merge = (object) array (
+        $merge = (object) array(
             'domains' => $input->getOption('merge-domains')
         );
 
@@ -87,20 +90,6 @@ class DumpCommand extends ContainerAwareCommand
         $this
             ->getContainer()
             ->get('bazinga.jstranslation.translation_dumper')
-            ->dump($this->targetPath, $this->getTranslationsPath($input->getOption('path')), $formats, $merge);
-    }
-
-    /**
-     * Get translations path from the router defined or use the default one.
-     */
-    private function getTranslationsPath($path)
-    {
-        $translationsPathOverriden = empty($path) ? 'translations' : $path;
-        $route = $this->getContainer()->get('router')->getRouteCollection()->get('bazinga_jstranslation_js');
-        if (empty($route)) {
-            return $translationsPathOverriden;
-        }
-
-        return $route->getPath();
+            ->dump($this->targetPath, $input->getOption('pattern'), $formats, $merge);
     }
 }

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -35,9 +35,8 @@ class DumpCommand extends ContainerAwareCommand
             ->addOption(
                 'pattern',
                 null,
-                InputOption::VALUE_OPTIONAL,
-                'the route pattern',
-                TranslationDumper::DEFAULT_TRANSLATION_PATTERN
+                InputOption::VALUE_REQUIRED,
+                'The route pattern: e.g. "/translations/{domain}.{_format}"'
             )
             ->addOption(
                 'format',

--- a/DependencyInjection/BazingaJsTranslationExtension.php
+++ b/DependencyInjection/BazingaJsTranslationExtension.php
@@ -10,6 +10,7 @@ use Symfony\Component\Config\Definition\Processor;
 
 /**
  * @author William DURAND <william.durand1@gmail.com>
+ * @author Hugo Monteiro <hugo.monteiro@gmail.com>
  */
 class BazingaJsTranslationExtension extends Extension
 {
@@ -39,9 +40,9 @@ class BazingaJsTranslationExtension extends Extension
 
         $container
             ->getDefinition('bazinga.jstranslation.translation_dumper')
-            ->replaceArgument(4, $config['locale_fallback'])
-            ->replaceArgument(5, $config['default_domain'])
-            ->replaceArgument(6, $config['active_locales'])
-            ->replaceArgument(7, $config['active_domains']);
+            ->replaceArgument(3, $config['locale_fallback'])
+            ->replaceArgument(4, $config['default_domain'])
+            ->replaceArgument(5, $config['active_locales'])
+            ->replaceArgument(6, $config['active_domains']);
     }
 }

--- a/Dumper/TranslationDumper.php
+++ b/Dumper/TranslationDumper.php
@@ -114,7 +114,7 @@ class TranslationDumper
      * Dump all translation files.
      *
      * @param string $target Target directory.
-     * @param string $pattern e.g.
+     * @param string $pattern route path
      * @param string[] $formats Formats to generate.
      * @param \stdClass $merge Merge options.
      */

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,7 +15,6 @@
         <service id="bazinga.jstranslation.translation_dumper" class="%bazinga.jstranslation.translation_dumper.class%">
             <argument type="service" id="templating" />
             <argument type="service" id="bazinga.jstranslation.translation_finder" />
-            <argument type="service" id="router" />
             <argument type="service" id="filesystem" />
             <argument></argument> <!-- fallback (locale) -->
             <argument></argument> <!-- default domain    -->

--- a/Tests/Dumper/TranslationDumperTest.php
+++ b/Tests/Dumper/TranslationDumperTest.php
@@ -2,6 +2,7 @@
 
 namespace Bazinga\JsTranslationBundle\Tests\Finder;
 
+use Bazinga\Bundle\JsTranslationBundle\Dumper\TranslationDumper;
 use Bazinga\Bundle\JsTranslationBundle\Tests\WebTestCase;
 
 /**
@@ -145,11 +146,6 @@ JSON;
 
     private $dumper;
 
-    /**
-     * @var string translations path
-     */
-    private $path;
-
     public function setUp()
     {
         $container = $this->getContainer();
@@ -157,7 +153,6 @@ JSON;
         $this->target     = sys_get_temp_dir() . '/bazinga/js-translation-bundle';
         $this->filesystem = $container->get('filesystem');
         $this->dumper     = $container->get('bazinga.jstranslation.translation_dumper');
-        $this->path       = 'translations';
 
         $this->filesystem->mkdir($this->target);
     }
@@ -171,57 +166,63 @@ JSON;
 
     public function testDumpPerDomain()
     {
-        $this->dumper->dump($this->target);
+        $this->dumper->dump(
+            $this->target
+        );
 
         foreach (array(
-            'messages/en.js',
-            'messages/en.json',
-            'messages/fr.js',
-            'messages/fr.json',
-            'foo/en.js',
-            'foo/en.json',
-            'numerics/en.js',
-            'numerics/en.json',
-        ) as $file) {
-            $this->assertFileExists($this->target . '/' . $this->path . '/' . $file);
+                     'messages/en.js',
+                     'messages/en.json',
+                     'messages/fr.js',
+                     'messages/fr.json',
+                     'foo/en.js',
+                     'foo/en.json',
+                     'numerics/en.js',
+                     'numerics/en.json',
+                 ) as $file) {
+            $this->assertFileExists($this->target . '/translations/' . $file);
         }
 
         foreach (array(
-            'front/en.js',
-            'front/en.json',
-            'front/fr.js',
-            'front/fr.json',
-            'messages/es.js',
-            'messages/es.json',
-        ) as $file) {
-            $this->assertFileNotExists($this->target . '/' . $this->path . '/' . $file);
+                     'front/en.js',
+                     'front/en.json',
+                     'front/fr.js',
+                     'front/fr.json',
+                     'messages/es.js',
+                     'messages/es.json',
+                 ) as $file) {
+            $this->assertFileNotExists($this->target . '/translations/' . $file);
         }
 
-        $this->assertEquals(self::JS_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/en.js'));
+        $this->assertEquals(self::JS_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/en.js'));
 
-        $this->assertEquals(self::JS_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/fr.js'));
+        $this->assertEquals(self::JS_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/fr.js'));
 
-        $this->assertEquals(self::JS_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/en.js'));
+        $this->assertEquals(self::JS_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/en.js'));
 
-        $this->assertEquals(self::JS_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/fr.js'));
+        $this->assertEquals(self::JS_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/fr.js'));
 
-        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.js'));
+        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/translations/config.js'));
 
-        $this->assertEquals(self::JSON_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/en.json'));
+        $this->assertEquals(self::JSON_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/en.json'));
 
-        $this->assertEquals(self::JSON_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/fr.json'));
+        $this->assertEquals(self::JSON_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/fr.json'));
 
-        $this->assertEquals(self::JSON_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/en.json'));
+        $this->assertEquals(self::JSON_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/en.json'));
 
-        $this->assertEquals(self::JSON_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/fr.json'));
+        $this->assertEquals(self::JSON_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/fr.json'));
 
-        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.json'));
-
+        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/translations/config.json'));
     }
 
     public function testDumpPerLocale()
     {
-        $this->dumper->dump($this->target, $this->path, array(), (object) array('domains' => true));
+        $this->dumper->dump(
+            $this->target,
+            TranslationDumper::DEFAULT_TRANSLATION_PATTERN,
+            array(),
+            (object) array('domains' => true)
+        );
 
         foreach (array(
                      'en.js',
@@ -229,33 +230,36 @@ JSON;
                      'fr.js',
                      'fr.json',
                  ) as $file) {
-            $this->assertFileExists($this->target . '/' . $this->path . '/' . $file);
+            $this->assertFileExists($this->target . '/translations/' . $file);
         }
 
         foreach (array(
                      'es.js',
                      'es.json',
                  ) as $file) {
-            $this->assertFileNotExists($this->target . '/' . $this->path . '/' . $file);
+            $this->assertFileNotExists($this->target . '/translations/' . $file);
         }
 
-        $this->assertEquals(self::JS_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/en.js'));
+        $this->assertEquals(self::JS_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/en.js'));
 
-        $this->assertEquals(self::JS_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/fr.js'));
+        $this->assertEquals(self::JS_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/fr.js'));
 
-        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.js'));
+        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/translations/config.js'));
 
-        $this->assertEquals(self::JSON_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/en.json'));
+        $this->assertEquals(self::JSON_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/en.json'));
 
-        $this->assertEquals(self::JSON_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/fr.json'));
+        $this->assertEquals(self::JSON_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/fr.json'));
 
-        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.json'));
-
+        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/translations/config.json'));
     }
 
     public function testDumpJsPerDomain()
     {
-        $this->dumper->dump($this->target, $this->path, array('js'));
+        $this->dumper->dump(
+            $this->target,
+            TranslationDumper::DEFAULT_TRANSLATION_PATTERN,
+            array('js')
+        );
 
         foreach (array(
                      'foo/en.js',
@@ -264,7 +268,7 @@ JSON;
                      'numerics/en.js',
                      'numerics/fr.js',
                  ) as $file) {
-            $this->assertFileExists($this->target . '/' . $this->path . '/' . $file);
+            $this->assertFileExists($this->target . '/translations/' . $file);
         }
 
         foreach (array(
@@ -280,24 +284,27 @@ JSON;
                      'numerics/en.json',
                      'numerics/fr.json',
                  ) as $file) {
-            $this->assertFileNotExists($this->target . '/' . $this->path . '/' . $file);
+            $this->assertFileNotExists($this->target . '/translations/' . $file);
         }
 
-        $this->assertEquals(self::JS_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/en.js'));
+        $this->assertEquals(self::JS_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/en.js'));
 
-        $this->assertEquals(self::JS_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/fr.js'));
+        $this->assertEquals(self::JS_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/fr.js'));
 
-        $this->assertEquals(self::JS_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/en.js'));
+        $this->assertEquals(self::JS_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/en.js'));
 
-        $this->assertEquals(self::JS_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/fr.js'));
+        $this->assertEquals(self::JS_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/fr.js'));
 
-        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.js'));
-
+        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/translations/config.js'));
     }
 
     public function testDumpJsonPerDomain()
     {
-        $this->dumper->dump($this->target, $this->path, array('json'));
+        $this->dumper->dump(
+            $this->target,
+            TranslationDumper::DEFAULT_TRANSLATION_PATTERN,
+            array('json')
+        );
 
         foreach (array(
                      'foo/en.json',
@@ -306,7 +313,7 @@ JSON;
                      'numerics/en.json',
                      'numerics/fr.json',
                  ) as $file) {
-            $this->assertFileExists($this->target . '/' . $this->path . '/' . $file);
+            $this->assertFileExists($this->target . '/translations/' . $file);
         }
 
         foreach (array(
@@ -322,30 +329,34 @@ JSON;
                      'numerics/en.js',
                      'numerics/fr.js',
                  ) as $file) {
-            $this->assertFileNotExists($this->target . '/' . $this->path . '/' . $file);
+            $this->assertFileNotExists($this->target . '/translations/' . $file);
         }
 
-        $this->assertEquals(self::JSON_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/en.json'));
+        $this->assertEquals(self::JSON_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/en.json'));
 
-        $this->assertEquals(self::JSON_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/fr.json'));
+        $this->assertEquals(self::JSON_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/fr.json'));
 
-        $this->assertEquals(self::JSON_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/en.json'));
+        $this->assertEquals(self::JSON_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/en.json'));
 
-        $this->assertEquals(self::JSON_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/fr.json'));
+        $this->assertEquals(self::JSON_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/fr.json'));
 
-        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.json'));
-
+        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/translations/config.json'));
     }
 
     public function testDumpJsPerLocale()
     {
-        $this->dumper->dump($this->target, $this->path, array('js'), (object) array('domains' => true));
+        $this->dumper->dump(
+            $this->target,
+            TranslationDumper::DEFAULT_TRANSLATION_PATTERN,
+            array('js'),
+            (object) array('domains' => true)
+        );
 
         foreach (array(
                      'en.js',
                      'fr.js',
                  ) as $file) {
-            $this->assertFileExists($this->target . '/' . $this->path . '/' . $file);
+            $this->assertFileExists($this->target . '/translations/' . $file);
         }
 
         foreach (array(
@@ -354,26 +365,30 @@ JSON;
                      'es.json',
                      'fr.json',
                  ) as $file) {
-            $this->assertFileNotExists($this->target . '/'. $this->path . '/' . $file);
+            $this->assertFileNotExists($this->target . '/translations/' . $file);
         }
 
-        $this->assertEquals(self::JS_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/en.js'));
+        $this->assertEquals(self::JS_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/en.js'));
 
-        $this->assertEquals(self::JS_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/fr.js'));
+        $this->assertEquals(self::JS_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/fr.js'));
 
-        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.js'));
-
+        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/translations/config.js'));
     }
 
     public function testDumpJsonPerLocale()
     {
-        $this->dumper->dump($this->target, $this->path, array('json'), (object) array('domains' => true));
+        $this->dumper->dump(
+            $this->target,
+            TranslationDumper::DEFAULT_TRANSLATION_PATTERN,
+            array('json'),
+            (object) array('domains' => true)
+        );
 
         foreach (array(
                      'en.json',
                      'fr.json',
                  ) as $file) {
-            $this->assertFileExists($this->target . '/' . $this->path . '/' . $file);
+            $this->assertFileExists($this->target . '/translations/' . $file);
         }
 
         foreach (array(
@@ -382,14 +397,13 @@ JSON;
                      'es.json',
                      'fr.js',
                  ) as $file) {
-            $this->assertFileNotExists($this->target . '/' . $this->path . '/' . $file);
+            $this->assertFileNotExists($this->target . '/translations/' . $file);
         }
 
-        $this->assertEquals(self::JSON_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/en.json'));
+        $this->assertEquals(self::JSON_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/en.json'));
 
-        $this->assertEquals(self::JSON_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/fr.json'));
+        $this->assertEquals(self::JSON_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/fr.json'));
 
-        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.json'));
-
+        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/translations/config.json'));
     }
 }

--- a/Tests/Dumper/TranslationDumperTest.php
+++ b/Tests/Dumper/TranslationDumperTest.php
@@ -6,6 +6,7 @@ use Bazinga\Bundle\JsTranslationBundle\Tests\WebTestCase;
 
 /**
  * @author Adrien Russo <adrien.russo.qc@gmail.com>
+ * @author Hugo Monteiro <hugo.monteiro@gmail.com>
  */
 class TranslationDumperTest extends WebTestCase
 {
@@ -144,6 +145,11 @@ JSON;
 
     private $dumper;
 
+    /**
+     * @var string translations path
+     */
+    private $path;
+
     public function setUp()
     {
         $container = $this->getContainer();
@@ -151,6 +157,7 @@ JSON;
         $this->target     = sys_get_temp_dir() . '/bazinga/js-translation-bundle';
         $this->filesystem = $container->get('filesystem');
         $this->dumper     = $container->get('bazinga.jstranslation.translation_dumper');
+        $this->path       = 'translations';
 
         $this->filesystem->mkdir($this->target);
     }
@@ -176,7 +183,7 @@ JSON;
             'numerics/en.js',
             'numerics/en.json',
         ) as $file) {
-            $this->assertFileExists($this->target . '/translations/' . $file);
+            $this->assertFileExists($this->target . '/' . $this->path . '/' . $file);
         }
 
         foreach (array(
@@ -187,34 +194,34 @@ JSON;
             'messages/es.js',
             'messages/es.json',
         ) as $file) {
-            $this->assertFileNotExists($this->target . '/translations/' . $file);
+            $this->assertFileNotExists($this->target . '/' . $this->path . '/' . $file);
         }
 
-        $this->assertEquals(self::JS_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/en.js'));
+        $this->assertEquals(self::JS_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/en.js'));
 
-        $this->assertEquals(self::JS_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/fr.js'));
+        $this->assertEquals(self::JS_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/fr.js'));
 
-        $this->assertEquals(self::JS_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/en.js'));
+        $this->assertEquals(self::JS_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/en.js'));
 
-        $this->assertEquals(self::JS_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/fr.js'));
+        $this->assertEquals(self::JS_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/fr.js'));
 
-        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/translations/config.js'));
+        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.js'));
 
-        $this->assertEquals(self::JSON_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/en.json'));
+        $this->assertEquals(self::JSON_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/en.json'));
 
-        $this->assertEquals(self::JSON_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/fr.json'));
+        $this->assertEquals(self::JSON_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/fr.json'));
 
-        $this->assertEquals(self::JSON_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/en.json'));
+        $this->assertEquals(self::JSON_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/en.json'));
 
-        $this->assertEquals(self::JSON_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/fr.json'));
+        $this->assertEquals(self::JSON_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/fr.json'));
 
-        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/translations/config.json'));
+        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.json'));
 
     }
 
     public function testDumpPerLocale()
     {
-        $this->dumper->dump($this->target, array(), (object) array('domains' => true));
+        $this->dumper->dump($this->target, $this->path, array(), (object) array('domains' => true));
 
         foreach (array(
                      'en.js',
@@ -222,33 +229,33 @@ JSON;
                      'fr.js',
                      'fr.json',
                  ) as $file) {
-            $this->assertFileExists($this->target . '/translations/' . $file);
+            $this->assertFileExists($this->target . '/' . $this->path . '/' . $file);
         }
 
         foreach (array(
                      'es.js',
                      'es.json',
                  ) as $file) {
-            $this->assertFileNotExists($this->target . '/translations/' . $file);
+            $this->assertFileNotExists($this->target . '/' . $this->path . '/' . $file);
         }
 
-        $this->assertEquals(self::JS_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/en.js'));
+        $this->assertEquals(self::JS_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/en.js'));
 
-        $this->assertEquals(self::JS_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/fr.js'));
+        $this->assertEquals(self::JS_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/fr.js'));
 
-        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/translations/config.js'));
+        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.js'));
 
-        $this->assertEquals(self::JSON_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/en.json'));
+        $this->assertEquals(self::JSON_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/en.json'));
 
-        $this->assertEquals(self::JSON_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/fr.json'));
+        $this->assertEquals(self::JSON_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/fr.json'));
 
-        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/translations/config.json'));
+        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.json'));
 
     }
 
     public function testDumpJsPerDomain()
     {
-        $this->dumper->dump($this->target, array('js'));
+        $this->dumper->dump($this->target, $this->path, array('js'));
 
         foreach (array(
                      'foo/en.js',
@@ -257,7 +264,7 @@ JSON;
                      'numerics/en.js',
                      'numerics/fr.js',
                  ) as $file) {
-            $this->assertFileExists($this->target . '/translations/' . $file);
+            $this->assertFileExists($this->target . '/' . $this->path . '/' . $file);
         }
 
         foreach (array(
@@ -273,24 +280,24 @@ JSON;
                      'numerics/en.json',
                      'numerics/fr.json',
                  ) as $file) {
-            $this->assertFileNotExists($this->target . '/translations/' . $file);
+            $this->assertFileNotExists($this->target . '/' . $this->path . '/' . $file);
         }
 
-        $this->assertEquals(self::JS_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/en.js'));
+        $this->assertEquals(self::JS_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/en.js'));
 
-        $this->assertEquals(self::JS_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/fr.js'));
+        $this->assertEquals(self::JS_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/fr.js'));
 
-        $this->assertEquals(self::JS_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/en.js'));
+        $this->assertEquals(self::JS_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/en.js'));
 
-        $this->assertEquals(self::JS_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/fr.js'));
+        $this->assertEquals(self::JS_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/fr.js'));
 
-        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/translations/config.js'));
+        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.js'));
 
     }
 
     public function testDumpJsonPerDomain()
     {
-        $this->dumper->dump($this->target, array('json'));
+        $this->dumper->dump($this->target, $this->path, array('json'));
 
         foreach (array(
                      'foo/en.json',
@@ -299,7 +306,7 @@ JSON;
                      'numerics/en.json',
                      'numerics/fr.json',
                  ) as $file) {
-            $this->assertFileExists($this->target . '/translations/' . $file);
+            $this->assertFileExists($this->target . '/' . $this->path . '/' . $file);
         }
 
         foreach (array(
@@ -315,30 +322,30 @@ JSON;
                      'numerics/en.js',
                      'numerics/fr.js',
                  ) as $file) {
-            $this->assertFileNotExists($this->target . '/translations/' . $file);
+            $this->assertFileNotExists($this->target . '/' . $this->path . '/' . $file);
         }
 
-        $this->assertEquals(self::JSON_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/en.json'));
+        $this->assertEquals(self::JSON_EN_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/en.json'));
 
-        $this->assertEquals(self::JSON_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/translations/messages/fr.json'));
+        $this->assertEquals(self::JSON_FR_MESSAGES_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/messages/fr.json'));
 
-        $this->assertEquals(self::JSON_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/en.json'));
+        $this->assertEquals(self::JSON_EN_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/en.json'));
 
-        $this->assertEquals(self::JSON_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/translations/numerics/fr.json'));
+        $this->assertEquals(self::JSON_FR_NUMERICS_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/numerics/fr.json'));
 
-        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/translations/config.json'));
+        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.json'));
 
     }
 
     public function testDumpJsPerLocale()
     {
-        $this->dumper->dump($this->target, array('js'), (object) array('domains' => true));
+        $this->dumper->dump($this->target, $this->path, array('js'), (object) array('domains' => true));
 
         foreach (array(
                      'en.js',
                      'fr.js',
                  ) as $file) {
-            $this->assertFileExists($this->target . '/translations/' . $file);
+            $this->assertFileExists($this->target . '/' . $this->path . '/' . $file);
         }
 
         foreach (array(
@@ -347,26 +354,26 @@ JSON;
                      'es.json',
                      'fr.json',
                  ) as $file) {
-            $this->assertFileNotExists($this->target . '/translations/' . $file);
+            $this->assertFileNotExists($this->target . '/'. $this->path . '/' . $file);
         }
 
-        $this->assertEquals(self::JS_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/en.js'));
+        $this->assertEquals(self::JS_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/en.js'));
 
-        $this->assertEquals(self::JS_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/fr.js'));
+        $this->assertEquals(self::JS_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/fr.js'));
 
-        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/translations/config.js'));
+        $this->assertEquals(self::JS_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.js'));
 
     }
 
     public function testDumpJsonPerLocale()
     {
-        $this->dumper->dump($this->target, array('json'), (object) array('domains' => true));
+        $this->dumper->dump($this->target, $this->path, array('json'), (object) array('domains' => true));
 
         foreach (array(
                      'en.json',
                      'fr.json',
                  ) as $file) {
-            $this->assertFileExists($this->target . '/translations/' . $file);
+            $this->assertFileExists($this->target . '/' . $this->path . '/' . $file);
         }
 
         foreach (array(
@@ -375,14 +382,14 @@ JSON;
                      'es.json',
                      'fr.js',
                  ) as $file) {
-            $this->assertFileNotExists($this->target . '/translations/' . $file);
+            $this->assertFileNotExists($this->target . '/' . $this->path . '/' . $file);
         }
 
-        $this->assertEquals(self::JSON_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/en.json'));
+        $this->assertEquals(self::JSON_EN_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/en.json'));
 
-        $this->assertEquals(self::JSON_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/translations/fr.json'));
+        $this->assertEquals(self::JSON_FR_MERGED_TRANSLATIONS, file_get_contents($this->target . '/' . $this->path . '/fr.json'));
 
-        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/translations/config.json'));
+        $this->assertEquals(self::JSON_CONFIG, file_get_contents($this->target . '/' . $this->path . '/config.json'));
 
     }
 }


### PR DESCRIPTION
closes #190 

In some cases we don’t want to add the bazingaJs routes because we just generate the static file with all the translations in order to avoid the amount of requests to generate the file.

