### PR TITLE
fix searching definition/alias for translator.default service

### DIFF
--- a/DependencyInjection/Compiler/TranslationResourceFilesPass.php
+++ b/DependencyInjection/Compiler/TranslationResourceFilesPass.php
@@ -4,7 +4,6 @@ namespace Bazinga\Bundle\JsTranslationBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * @author Hugo MONTEIRO <hugo.monteiro@gmail.com>
@@ -13,7 +12,7 @@ class TranslationResourceFilesPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('translator.default')) {
+        if (!$container->has('translator.default')) {
             return;
         }
 
@@ -27,8 +26,8 @@ class TranslationResourceFilesPass implements CompilerPassInterface
     {
         $translationFiles = array();
 
-        $methodCalls = $container->getDefinition('translator.default')->getMethodCalls();
-        foreach($methodCalls as $methodCall) {
+        $methodCalls = $container->findDefinition('translator.default')->getMethodCalls();
+        foreach ($methodCalls as $methodCall) {
             if ($methodCall[0] === 'addResource') {
                 $locale = $methodCall[1][2];
                 $filename = $methodCall[1][1];
@@ -48,7 +47,7 @@ class TranslationResourceFilesPass implements CompilerPassInterface
     {
         $translationFiles = array();
 
-        $translatorOptions = $container->getDefinition('translator.default')->getArgument(3);
+        $translatorOptions = $container->findDefinition('translator.default')->getArgument(3);
         if (isset($translatorOptions['resource_files'])) {
             $translationFiles = $translatorOptions['resource_files'];
         }


### PR DESCRIPTION
In latest symfony versions translator.default isn't defined as a service but as an alias
So $container->hasDefinition('translator.default') always return false even if service exists