### PR TITLE
Add support for Symfony 3.3

### DIFF
--- a/DependencyInjection/Compiler/TranslationResourceFilesPass.php
+++ b/DependencyInjection/Compiler/TranslationResourceFilesPass.php
@@ -4,6 +4,7 @@ namespace Bazinga\Bundle\JsTranslationBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 
 /**
  * @author Hugo MONTEIRO <hugo.monteiro@gmail.com>
@@ -46,8 +47,14 @@ class TranslationResourceFilesPass implements CompilerPassInterface
     private function getTranslationFiles(ContainerBuilder $container)
     {
         $translationFiles = array();
+        $translator = $container->findDefinition('translator.default');
 
-        $translatorOptions = $container->findDefinition('translator.default')->getArgument(3);
+        try {
+            $translatorOptions = $translator->getArgument(4);
+        } catch (OutOfBoundsException $e) {
+            $translatorOptions = $translator->getArgument(3);
+        }
+        
         if (isset($translatorOptions['resource_files'])) {
             $translationFiles = $translatorOptions['resource_files'];
         }

--- a/DependencyInjection/Compiler/TranslationResourceFilesPass.php
+++ b/DependencyInjection/Compiler/TranslationResourceFilesPass.php
@@ -49,7 +49,13 @@ class TranslationResourceFilesPass implements CompilerPassInterface
         $translationFiles = array();
         $translator = $container->findDefinition('translator.default');
 
-        $translatorOptions = array_merge($translator->getArgument(4), $translator->getArgument(3));
+        try {
+            $translatorOptions = $translator->getArgument(4);
+        } catch (OutOfBoundsException $e) {
+            $translatorOptions = array();
+        }
+
+        $translatorOptions = array_merge($translatorOptions, $translator->getArgument(3));
         
         if (isset($translatorOptions['resource_files'])) {
             $translationFiles = $translatorOptions['resource_files'];

--- a/DependencyInjection/Compiler/TranslationResourceFilesPass.php
+++ b/DependencyInjection/Compiler/TranslationResourceFilesPass.php
@@ -49,11 +49,7 @@ class TranslationResourceFilesPass implements CompilerPassInterface
         $translationFiles = array();
         $translator = $container->findDefinition('translator.default');
 
-        try {
-            $translatorOptions = $translator->getArgument(4);
-        } catch (OutOfBoundsException $e) {
-            $translatorOptions = $translator->getArgument(3);
-        }
+        $translatorOptions = array_merge($translator->getArgument(4), $translator->getArgument(3));
         
         if (isset($translatorOptions['resource_files'])) {
             $translationFiles = $translatorOptions['resource_files'];


### PR DESCRIPTION
Since symfony/symfony#22010 there is now an extra argument to the translator constructor, which means the `$options` parameter moves one index up