### PR TITLE
Remove unnecessary use of `Translator` in getTranslations.js.twig

### DIFF
--- a/Resources/views/config.js.twig
+++ b/Resources/views/config.js.twig
@@ -1,4 +1,4 @@
-(function (Translator) {
-    Translator.fallback      = '{{ fallback }}';
-    Translator.defaultDomain = '{{ defaultDomain }}';
+(function (t) {
+t.fallback = '{{ fallback }}';
+t.defaultDomain = '{{ defaultDomain }}';
 })(Translator);

--- a/Resources/views/getTranslations.js.twig
+++ b/Resources/views/getTranslations.js.twig
@@ -1,13 +1,13 @@
-(function (Translator) {
+(function (t) {
 {% if include_config %}
-    Translator.fallback      = '{{ fallback }}';
-    Translator.defaultDomain = '{{ defaultDomain }}';
+t.fallback = '{{ fallback }}';
+t.defaultDomain = '{{ defaultDomain }}';
 {% endif %}
 {% for locale, domains in translations %}
-    // {{ locale }}
+// {{ locale }}
 {% for domain, messages in domains %}
 {% for key, message in messages %}
-    Translator.add({{ key|json_encode|raw }}, {{ message|json_encode|raw }}, "{{ domain }}", "{{ locale }}");
+t.add({{ key|json_encode|raw }}, {{ message|json_encode|raw }}, "{{ domain }}", "{{ locale }}");
 {% endfor %}
 {% endfor %}
 {% endfor %}

--- a/Tests/Controller/ControllerTest.php
+++ b/Tests/Controller/ControllerTest.php
@@ -87,11 +87,11 @@ JSON
         $response = $client->getResponse();
 
         $this->assertEquals(<<<JS
-(function (Translator) {
-    Translator.fallback      = 'en';
-    Translator.defaultDomain = 'messages';
-    // en
-    Translator.add("hello", "hello", "messages", "en");
+(function (t) {
+t.fallback = 'en';
+t.defaultDomain = 'messages';
+// en
+t.add("hello", "hello", "messages", "en");
 })(Translator);
 
 JS
@@ -106,13 +106,13 @@ JS
         $response = $client->getResponse();
 
         $this->assertEquals(<<<JS
-(function (Translator) {
-    Translator.fallback      = 'en';
-    Translator.defaultDomain = 'messages';
-    // en
-    Translator.add("hello", "hello", "messages", "en");
-    // fr
-    Translator.add("hello", "bonjour", "messages", "fr");
+(function (t) {
+t.fallback = 'en';
+t.defaultDomain = 'messages';
+// en
+t.add("hello", "hello", "messages", "en");
+// fr
+t.add("hello", "bonjour", "messages", "fr");
 })(Translator);
 
 JS
@@ -127,10 +127,10 @@ JS
         $response = $client->getResponse();
 
         $this->assertEquals(<<<JS
-(function (Translator) {
-    Translator.fallback      = 'en';
-    Translator.defaultDomain = 'messages';
-    // en
+(function (t) {
+t.fallback = 'en';
+t.defaultDomain = 'messages';
+// en
 })(Translator);
 
 JS
@@ -145,10 +145,10 @@ JS
         $response = $client->getResponse();
 
         $this->assertEquals(<<<JS
-(function (Translator) {
-    Translator.fallback      = 'en';
-    Translator.defaultDomain = 'messages';
-    // pt
+(function (t) {
+t.fallback = 'en';
+t.defaultDomain = 'messages';
+// pt
 })(Translator);
 
 JS

--- a/Tests/Dumper/TranslationDumperTest.php
+++ b/Tests/Dumper/TranslationDumperTest.php
@@ -10,80 +10,80 @@ use Bazinga\Bundle\JsTranslationBundle\Tests\WebTestCase;
 class TranslationDumperTest extends WebTestCase
 {
     const JS_CONFIG = <<<JS
-(function (Translator) {
-    Translator.fallback      = 'en';
-    Translator.defaultDomain = 'messages';
+(function (t) {
+t.fallback = 'en';
+t.defaultDomain = 'messages';
 })(Translator);
 
 JS;
 
     const JS_EN_MERGED_TRANSLATIONS = <<<JS
-(function (Translator) {
-    // en
-    Translator.add("foo", "bar", "foo", "en");
-    Translator.add("hello", "hello", "messages", "en");
-    Translator.add(7, "Nos occasions", "numerics", "en");
-    Translator.add(8, "Nous contacter", "numerics", "en");
-    Translator.add(12, "pr\u00e9nom", "numerics", "en");
-    Translator.add(13, "nom", "numerics", "en");
-    Translator.add(14, "adresse", "numerics", "en");
-    Translator.add(15, "code postal", "numerics", "en");
+(function (t) {
+// en
+t.add("foo", "bar", "foo", "en");
+t.add("hello", "hello", "messages", "en");
+t.add(7, "Nos occasions", "numerics", "en");
+t.add(8, "Nous contacter", "numerics", "en");
+t.add(12, "pr\u00e9nom", "numerics", "en");
+t.add(13, "nom", "numerics", "en");
+t.add(14, "adresse", "numerics", "en");
+t.add(15, "code postal", "numerics", "en");
 })(Translator);
 
 JS;
 
     const JS_EN_MESSAGES_TRANSLATIONS = <<<JS
-(function (Translator) {
-    // en
-    Translator.add("hello", "hello", "messages", "en");
+(function (t) {
+// en
+t.add("hello", "hello", "messages", "en");
 })(Translator);
 
 JS;
 
     const JS_EN_NUMERICS_TRANSLATIONS = <<<JS
-(function (Translator) {
-    // en
-    Translator.add(7, "Nos occasions", "numerics", "en");
-    Translator.add(8, "Nous contacter", "numerics", "en");
-    Translator.add(12, "pr\u00e9nom", "numerics", "en");
-    Translator.add(13, "nom", "numerics", "en");
-    Translator.add(14, "adresse", "numerics", "en");
-    Translator.add(15, "code postal", "numerics", "en");
+(function (t) {
+// en
+t.add(7, "Nos occasions", "numerics", "en");
+t.add(8, "Nous contacter", "numerics", "en");
+t.add(12, "pr\u00e9nom", "numerics", "en");
+t.add(13, "nom", "numerics", "en");
+t.add(14, "adresse", "numerics", "en");
+t.add(15, "code postal", "numerics", "en");
 })(Translator);
 
 JS;
 
     const JS_FR_MERGED_TRANSLATIONS = <<<JS
-(function (Translator) {
-    // fr
-    Translator.add("hello", "bonjour", "messages", "fr");
-    Translator.add(7, "Nos occasions", "numerics", "fr");
-    Translator.add(8, "Nous contacter", "numerics", "fr");
-    Translator.add(12, "pr\u00e9nom", "numerics", "fr");
-    Translator.add(13, "nom", "numerics", "fr");
-    Translator.add(14, "adresse", "numerics", "fr");
-    Translator.add(15, "code postal", "numerics", "fr");
+(function (t) {
+// fr
+t.add("hello", "bonjour", "messages", "fr");
+t.add(7, "Nos occasions", "numerics", "fr");
+t.add(8, "Nous contacter", "numerics", "fr");
+t.add(12, "pr\u00e9nom", "numerics", "fr");
+t.add(13, "nom", "numerics", "fr");
+t.add(14, "adresse", "numerics", "fr");
+t.add(15, "code postal", "numerics", "fr");
 })(Translator);
 
 JS;
 
     const JS_FR_MESSAGES_TRANSLATIONS = <<<JS
-(function (Translator) {
-    // fr
-    Translator.add("hello", "bonjour", "messages", "fr");
+(function (t) {
+// fr
+t.add("hello", "bonjour", "messages", "fr");
 })(Translator);
 
 JS;
 
     const JS_FR_NUMERICS_TRANSLATIONS = <<<JS
-(function (Translator) {
-    // fr
-    Translator.add(7, "Nos occasions", "numerics", "fr");
-    Translator.add(8, "Nous contacter", "numerics", "fr");
-    Translator.add(12, "pr\u00e9nom", "numerics", "fr");
-    Translator.add(13, "nom", "numerics", "fr");
-    Translator.add(14, "adresse", "numerics", "fr");
-    Translator.add(15, "code postal", "numerics", "fr");
+(function (t) {
+// fr
+t.add(7, "Nos occasions", "numerics", "fr");
+t.add(8, "Nous contacter", "numerics", "fr");
+t.add(12, "pr\u00e9nom", "numerics", "fr");
+t.add(13, "nom", "numerics", "fr");
+t.add(14, "adresse", "numerics", "fr");
+t.add(15, "code postal", "numerics", "fr");
 })(Translator);
 
 JS;


### PR DESCRIPTION
No need to call `Translator` when it's injected already. Just use short `t`. 

For larger files it will help shave of some bytes on every request :)