### PR TITLE
add missing default for pattern in DumpCommand

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -36,7 +36,8 @@ class DumpCommand extends ContainerAwareCommand
                 'pattern',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'The route pattern: e.g. "/translations/{domain}.{_format}"'
+                'The route pattern: e.g. "/translations/{domain}.{_format}"',
+                TranslationDumper::DEFAULT_TRANSLATION_PATTERN
             )
             ->addOption(
                 'format',


### PR DESCRIPTION
Without this, I get this error if I don't use the `--pattern` option (it uses an empty pattern):

> [Symfony\Component\Debug\Exception\ContextErrorException]                                         
  Warning: file_put_contents(.../web/js/): failed to open stream: Is a directory