### PR TITLE
Fix Travis configuration for different distributions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ matrix:
     include:
       - php: 5.3
         dist: precise
-      - php: hhvm
-        dist: trusty
       - php: 5.6
         env: SYMFONY_VERSION='~2.7.0'
       - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: php
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6
     - 7.0
-    - hhvm
 
 sudo: false
 
@@ -29,6 +27,10 @@ script:
 matrix:
     fast_finish: true
     include:
+      - php: 5.3
+        dist: precise
+      - php: hhvm
+        dist: trusty
       - php: 5.6
         env: SYMFONY_VERSION='~2.7.0'
       - php: 5.6


### PR DESCRIPTION
HHVM is only available on trusty now, not on precise. And precise does not have PHP 5.3.

So this forces the distribution explicitly for both of them.
This fixes the HHVM job today, and ensures that the PHP 5.3 job keeps working when Travis migrates this repository to using trusty by default (they are currently deploying this upgrade little by little)?