### PR TITLE
[#206] Option added to merge fallback translations

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -51,6 +51,12 @@ class DumpCommand extends ContainerAwareCommand
                 null,
                 InputOption::VALUE_NONE,
                 'If set, all domains will be merged into a single file per language'
+            )
+            ->addOption(
+                'merge-fallback',
+                null,
+                InputOption::VALUE_NONE,
+                'If set, fallback translations will be merged into files which are missing translations - Currently, working only with --merge-domains option'
             );
     }
 
@@ -72,7 +78,8 @@ class DumpCommand extends ContainerAwareCommand
     {
         $formats = $input->getOption('format');
         $merge = (object) array(
-            'domains' => $input->getOption('merge-domains')
+            'domains' => $input->getOption('merge-domains'),
+            'fallback' => $input->getOption('merge-fallback')
         );
 
         if (!is_dir($dir = dirname($this->targetPath))) {

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -79,7 +79,7 @@ class DumpCommand extends ContainerAwareCommand
         $formats = $input->getOption('format');
         $merge = (object) array(
             'domains' => $input->getOption('merge-domains'),
-            'fallback' => $input->getOption('merge-fallback')
+            'fallback' => $input->getOption('merge-fallback'),
         );
 
         if (!is_dir($dir = dirname($this->targetPath))) {

--- a/Dumper/TranslationDumper.php
+++ b/Dumper/TranslationDumper.php
@@ -207,24 +207,23 @@ class TranslationDumper
         }
     }
 
-    private function dumpTranslationsPerLocale($pattern, array $formats, $target, bool $mergeFallback)
+    private function dumpTranslationsPerLocale($pattern, array $formats, $target, $mergeFallback)
     {
         $allTranslations = $this->getTranslations();
 
         foreach ($allTranslations as $locale => $domains) {
             $translations = array($locale => $domains);
 
-            if ($mergeFallback && $locale !== $this->localeFallback) {
-                foreach ($allTranslations[$this->localeFallback] as $domainIndex => $domainValue) {
-                    if (!isset($translations[$locale])) {
-                        $translations[$this->localeFallback] = array();
-                    }
-                    if (!isset($translations[$locale][$domainIndex])) {
-                        $translations[$this->localeFallback][$domainIndex] = array();
-                    }
-                    foreach ($domainValue as $translationIndex => $translationValue) {
-                        if (!isset($translations[$locale][$domainIndex][$translationIndex])) {
-                            $translations[$this->localeFallback][$domainIndex][$translationIndex] = $translationValue;
+            if ($mergeFallback) {
+                $localesFallback = array_unique(array(current(explode('_', $locale)), $this->localeFallback));
+                foreach ($localesFallback as $localeFallback) {
+                    if (!empty($localeFallback) && $locale !== $localeFallback && isset($allTranslations[$localeFallback])) {
+                        foreach ($allTranslations[$localeFallback] as $domain => $messages) {
+                            foreach ($messages as $key => $message) {
+                                if (!isset($translations[$locale][$domain][$key])) {
+                                    $translations[$localeFallback][$domain][$key] = $message;
+                                }
+                            }
                         }
                     }
                 }

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -179,7 +179,7 @@ Then, feed the translator via `Translator.fromJSON(myRetrievedJSONString)`.
 
 This bundle provides a command to dump the translation files:
 
-    php app/console bazinga:js-translation:dump [target] [--format=js|json] [--pattern=/translations/{domain}.{_format}] [--merge-domains]
+    php app/console bazinga:js-translation:dump [target] [--format=js|json] [--pattern=/translations/{domain}.{_format}] [--merge-domains] [--merge-fallback]
 
 The optional `target` argument allows you to override the target directory to
 dump JS translation files in. By default, it generates files in the `web/js/`
@@ -192,6 +192,9 @@ The `--pattern` option allows you to specify the url pattern that will be genera
 
 The `--merge-domains` option when set will generate only one file per locale with all the domains in it.
 For cases where you prefer to load all language strings at once.
+
+The `--merge-fallback` option when set will include fallback translations into locales which are missing translations.
+Currently, working only with `--merge-domains` option.
 
 You have to load a `config.js` file, which contains the configuration for the
 JS Translator, then you can load all translation files that have been dumped.

--- a/Tests/Dumper/TranslationDumperTest.php
+++ b/Tests/Dumper/TranslationDumperTest.php
@@ -221,7 +221,7 @@ JSON;
             $this->target,
             TranslationDumper::DEFAULT_TRANSLATION_PATTERN,
             array(),
-            (object) array('domains' => true, 'fallback' => true)
+            (object) array('domains' => true, 'fallback' => false)
         );
 
         foreach (array(
@@ -349,7 +349,7 @@ JSON;
             $this->target,
             TranslationDumper::DEFAULT_TRANSLATION_PATTERN,
             array('js'),
-            (object) array('domains' => true, 'fallback' => true)
+            (object) array('domains' => true, 'fallback' => false)
         );
 
         foreach (array(
@@ -381,7 +381,7 @@ JSON;
             $this->target,
             TranslationDumper::DEFAULT_TRANSLATION_PATTERN,
             array('json'),
-            (object) array('domains' => true, 'fallback' => true)
+            (object) array('domains' => true, 'fallback' => false)
         );
 
         foreach (array(

--- a/Tests/Dumper/TranslationDumperTest.php
+++ b/Tests/Dumper/TranslationDumperTest.php
@@ -221,7 +221,8 @@ JSON;
             $this->target,
             TranslationDumper::DEFAULT_TRANSLATION_PATTERN,
             array(),
-            (object) array('domains' => true)
+            (object) array('domains' => true),
+            (object) array('fallback' => true)
         );
 
         foreach (array(
@@ -349,7 +350,8 @@ JSON;
             $this->target,
             TranslationDumper::DEFAULT_TRANSLATION_PATTERN,
             array('js'),
-            (object) array('domains' => true)
+            (object) array('domains' => true),
+            (object) array('fallback' => true)
         );
 
         foreach (array(
@@ -381,7 +383,8 @@ JSON;
             $this->target,
             TranslationDumper::DEFAULT_TRANSLATION_PATTERN,
             array('json'),
-            (object) array('domains' => true)
+            (object) array('domains' => true),
+            (object) array('fallback' => true)
         );
 
         foreach (array(

--- a/Tests/Dumper/TranslationDumperTest.php
+++ b/Tests/Dumper/TranslationDumperTest.php
@@ -221,8 +221,7 @@ JSON;
             $this->target,
             TranslationDumper::DEFAULT_TRANSLATION_PATTERN,
             array(),
-            (object) array('domains' => true),
-            (object) array('fallback' => true)
+            (object) array('domains' => true, 'fallback' => true)
         );
 
         foreach (array(
@@ -350,8 +349,7 @@ JSON;
             $this->target,
             TranslationDumper::DEFAULT_TRANSLATION_PATTERN,
             array('js'),
-            (object) array('domains' => true),
-            (object) array('fallback' => true)
+            (object) array('domains' => true, 'fallback' => true)
         );
 
         foreach (array(
@@ -383,8 +381,7 @@ JSON;
             $this->target,
             TranslationDumper::DEFAULT_TRANSLATION_PATTERN,
             array('json'),
-            (object) array('domains' => true),
-            (object) array('fallback' => true)
+            (object) array('domains' => true, 'fallback' => true)
         );
 
         foreach (array(


### PR DESCRIPTION
I implemented the `--merge-fallback` option on dumper command which will merge fallback translations into files which are missing translations.
Currently, it's working only with `--merge-domains` option.

This pull request deals with #206 