### PR TITLE
Register command manually to avoid warning in Symfony 3.4

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -21,5 +21,8 @@
             <argument></argument> <!-- active locales -->
             <argument></argument> <!-- active domains -->
         </service>
+        <service id="bazinga.jstranslation.dump_command" class="Bazinga\Bundle\JsTranslationBundle\Command\DumpCommand">
+            <tag name="console.command" command="bazinga:js-translation:dump" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
Command auto-registration has been deprecated in Symfony 3.4, this PR aims to fix the generated warning: `Auto-registration of the command
  "Bazinga\Bundle\JsTranslationBundle\Command\DumpCommand" is deprecated since Symfony 3.4 and won't
  be supported in 4.0. Use PSR-4 based service discovery instead.`