### PR TITLE
Remove container injection in dump command

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -3,7 +3,7 @@
 namespace Bazinga\Bundle\JsTranslationBundle\Command;
 
 use Bazinga\Bundle\JsTranslationBundle\Dumper\TranslationDumper;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -13,9 +13,34 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @author Adrien Russo <adrien.russo.qc@gmail.com>
  * @author Hugo Monteiro <hugo.monteiro@gmail.com>
  */
-class DumpCommand extends ContainerAwareCommand
+class DumpCommand extends Command
 {
+    /**
+     * @var TranslationDumper
+     */
+    private $dumper;
+
+    /**
+     * @var string
+     */
+    private $kernelRootDir;
+
+    /**
+     * @var string
+     */
     private $targetPath;
+
+    /**
+     * @param TranslationDumper $dumper
+     * @param $kernelRootDir
+     */
+    public function __construct(TranslationDumper $dumper, $kernelRootDir)
+    {
+        $this->dumper = $dumper;
+        $this->kernelRootDir = $kernelRootDir;
+
+        parent::__construct();
+    }
 
     /**
      * {@inheritDoc}
@@ -61,8 +86,7 @@ class DumpCommand extends ContainerAwareCommand
     {
         parent::initialize($input, $output);
 
-        $this->targetPath = $input->getArgument('target') ?:
-            sprintf('%s/../web/js', $this->getContainer()->getParameter('kernel.root_dir'));
+        $this->targetPath = $input->getArgument('target') ?: sprintf('%s/../web/js', $this->kernelRootDir);
     }
 
     /**
@@ -87,9 +111,6 @@ class DumpCommand extends ContainerAwareCommand
             $this->targetPath
         ));
 
-        $this
-            ->getContainer()
-            ->get('bazinga.jstranslation.translation_dumper')
-            ->dump($this->targetPath, $input->getOption('pattern'), $formats, $merge);
+        $this->dumper->dump($this->targetPath, $input->getOption('pattern'), $formats, $merge);
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -22,6 +22,8 @@
             <argument></argument> <!-- active domains -->
         </service>
         <service id="bazinga.jstranslation.dump_command" class="Bazinga\Bundle\JsTranslationBundle\Command\DumpCommand">
+            <argument type="service" id="bazinga.jstranslation.translation_dumper" />
+            <argument>%kernel.root_dir%</argument>
             <tag name="console.command" command="bazinga:js-translation:dump" />
         </service>
     </services>


### PR DESCRIPTION
Getting private services is deprecated since Symfony 3.4 and will fail in 4.0. This PR will fix `[info] User Deprecated: The "bazinga.jstranslation.translation_dumper" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead.` warning for dump command.