### PR TITLE
Add tilde to Symfony 4.0 version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     }
     ],
     "require": {
-        "symfony/framework-bundle": "~2.7|~3.1|4.0",
-        "symfony/finder": "~2.7|~3.1|4.0",
-        "symfony/console": "~2.7|~3.1|4.0",
-        "symfony/intl": "~2.7|~3.1|4.0",
-        "symfony/translation":  "~2.7|~3.1|4.0",
-        "symfony/twig-bundle": "~2.7|~3.1|4.0"
+        "symfony/framework-bundle": "~2.7|~3.1|~4.0",
+        "symfony/finder": "~2.7|~3.1|~4.0",
+        "symfony/console": "~2.7|~3.1|~4.0",
+        "symfony/intl": "~2.7|~3.1|~4.0",
+        "symfony/translation":  "~2.7|~3.1|~4.0",
+        "symfony/twig-bundle": "~2.7|~3.1|~4.0"
     },
     "require-dev": {
         "symfony/asset": "~2.7|~3.1",


### PR DESCRIPTION
I gather this was a typo in #224 :smiley_cat: 