### PR TITLE
Handle Symfony default web path +/- v4.0

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Flex\Recipe;
 
 /**
  * @author Adrien Russo <adrien.russo.qc@gmail.com>
@@ -86,7 +87,11 @@ class DumpCommand extends Command
     {
         parent::initialize($input, $output);
 
-        $this->targetPath = $input->getArgument('target') ?: sprintf('%s/../web/js', $this->kernelRootDir);
+        $this->targetPath = $input->getArgument('target') ?: sprintf(
+            '%s/../%s/js',
+            $this->kernelRootDir,
+            class_exists('Symfony\Flex\Recipe') ? 'public' : 'web'
+        );
     }
 
     /**

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -58,9 +58,13 @@ _bazinga_jstranslation:
     resource: "@BazingaJsTranslationBundle/Resources/config/routing/routing.yml"
 ```
 
-Publish assets:
+Publish assets Symfony 2 & 3:
 
     php bin/console assets:install --symlink web
+
+Publish assets Symfony 4+ with Flex:
+
+    php app/console assets:install --symlink public
 
 ### Require via NPM (optional)
 
@@ -199,7 +203,7 @@ This bundle provides a command to dump the translation files:
 
 The optional `target` argument allows you to override the target directory to
 dump JS translation files in. By default, it generates files in the `web/js/`
-directory.
+directory for Symfony versions prior to 4.0, and `public/js/` for Flex installs.
 
 The `--format` option allows you to specify which formats must be included in the output.
 If you only need JSON files in your project you can do `--format=json`.

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Bazinga\JsTranslationBundle\Tests\Command;
+
+use Bazinga\Bundle\JsTranslationBundle\Command\DumpCommand;
+use Bazinga\Bundle\JsTranslationBundle\Tests\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * @covers \Bazinga\Bundle\JsTranslationBundle\Command\DumpCommand
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class DumpCommandTest extends WebTestCase
+{
+    private $transDumper;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->transDumper = $this->getMockBuilder('Bazinga\Bundle\JsTranslationBundle\Dumper\TranslationDumper')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+
+    public function providerExecute()
+    {
+        return [
+            'No options supplied' => array(
+                array(),
+                $this->getTargetDir(),
+                '/translations/{domain}.{_format}',
+                array(),
+                (object) array('domains' => null),
+            ),
+            'Target option supplied' => array(
+                array('target' => 'foo'),
+                'foo',
+                '/translations/{domain}.{_format}',
+                array(),
+                (object) array('domains' => null),
+            ),
+            'Pattern option supplied' => array(
+                array('--pattern' => '/foo/{_format}.{domain}'),
+                $this->getTargetDir(),
+                '/foo/{_format}.{domain}',
+                array(),
+                (object) array('domains' => null),
+            ),
+            'Format option supplied' => array(
+                array('--format' => ['json']),
+                $this->getTargetDir(),
+                '/translations/{domain}.{_format}',
+                array('json'),
+                (object) array('domains' => null),
+            ),
+            'Merge domains option supplied' => array(
+                array('--merge-domains' => true),
+                $this->getTargetDir(),
+                '/translations/{domain}.{_format}',
+                array(),
+                (object) array('domains' => true),
+            ),
+        ];
+    }
+
+    /**
+     * @dataProvider providerExecute
+     */
+    public function testExecute($cli, $target, $pattern, $format, $mergeDomains)
+    {
+        $kernel = static::createKernel();
+        $kernel->boot();
+
+        $this->transDumper
+            ->expects($this->once())
+            ->method('dump')
+            ->with($target, $pattern, $format, $mergeDomains)
+        ;
+
+        $application = new Application($kernel);
+        $application->add(new DumpCommand($this->transDumper, $this->getKernelRoot()));
+
+        $command = $application->find('bazinga:js-translation:dump');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => $command->getName()] + $cli);
+
+        $output = $commandTester->getDisplay();
+        $this->assertRegExp('#(Installing translation files in).*('.preg_quote($target, '/').' directory)#', $output);
+    }
+
+    private function getKernelRoot()
+    {
+        return sys_get_temp_dir().'/'.Kernel::VERSION;
+    }
+
+    private function getWebDir()
+    {
+        return class_exists('Symfony\Flex\Recipe') ? 'public' : 'web';
+    }
+
+    private function getTargetDir()
+    {
+        return $this->getKernelRoot() . '/../' . $this->getWebDir() . '/js';
+    }
+}

--- a/Tests/WebTestCase.php
+++ b/Tests/WebTestCase.php
@@ -45,7 +45,7 @@ abstract class WebTestCase extends BaseWebTestCase
         );
     }
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->deleteTmpDir();


### PR DESCRIPTION
Symfony 4+ defaults to `public/` for the web root. If I have done my job properly this should cover that for all supported Symfony versions.

Added tests for the command too. They are a separate commit as to me it made more sense, as it wasn't an adjustment of tests for a single change, rather initial coverage for the whole SUT. Happy to squash them though :smile: 