### PR TITLE
Fix deprecation "A tree builder without a root node is deprecated sin…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.6
     - 7.1
     - 7.2
 
@@ -27,7 +26,7 @@ script:
 matrix:
     fast_finish: true
     include:
-      - php: 5.6
+      - php: 7.1
         env: SYMFONY_VERSION='~3.4.0'
       - php: 7.2
         env: STABILITY=dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: php
 
 php:
-    - 5.4
-    - 5.5
-    - 5.6
     - 7.1
     - 7.2
 
@@ -29,11 +26,7 @@ script:
 matrix:
     fast_finish: true
     include:
-      - php: 5.6
-        env: SYMFONY_VERSION='~2.7.0'
-      - php: 5.6
-        env: SYMFONY_VERSION='~2.8.0'
-      - php: 5.6
-        env: SYMFONY_VERSION='~3.4.0'
+      - php: 7.1
+        env: SYMFONY_VERSION='~4.1.0'
       - php: 7.2
-        env: STABILITY=dev
+        env: STABILITY='~4.2.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+    - 5.6
     - 7.1
     - 7.2
 
@@ -26,7 +27,7 @@ script:
 matrix:
     fast_finish: true
     include:
-      - php: 7.1
-        env: SYMFONY_VERSION='~4.1.0'
+      - php: 5.6
+        env: SYMFONY_VERSION='~3.4.0'
       - php: 7.2
-        env: STABILITY='~4.2.0'
+        env: STABILITY=dev

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,9 +17,16 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder();
 
-        $builder->root('bazinga_js_translation')
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('bazinga_js_translation');
+        }
+
+        $rootNode
             ->fixXmlConfig('active_locale')
             ->fixXmlConfig('active_domain')
             ->children()
@@ -36,6 +43,6 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end();
 
-        return $builder;
+        return $rootNode;
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,7 +17,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('bazinga_js_translation');
 
         if (method_exists($treeBuilder, 'getRootNode')) {
             $rootNode = $treeBuilder->getRootNode();


### PR DESCRIPTION
…ce Symfony 4.2 and will not be supported anymore in 5.0."