### PR TITLE
On dump file, execute() should return int

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -112,5 +112,7 @@ class DumpCommand extends Command
         ));
 
         $this->dumper->dump($this->targetPath, $input->getOption('pattern'), $formats, $merge);
+        
+        return 0;
     }
 }


### PR DESCRIPTION
Return value of "Bazinga\Bundle\JsTranslationBundle\Command\DumpCommand::execute()" must be of the type int, NULL returned.