### PR TITLE
In SF5 execute() method of the command must return otherwise gives an error.

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -112,5 +112,7 @@ class DumpCommand extends Command
         ));
 
         $this->dumper->dump($this->targetPath, $input->getOption('pattern'), $formats, $merge);
+        
+        return 0;
     }
 }


### PR DESCRIPTION
https://symfony.com/blog/new-in-symfony-4-4-console-improvements

Returning the exit status is mandatory in Symfony 5, so better start adding those returns in your commands so you are ready to upgrade.