### PR TITLE
Fix Composer Deprecation

### DIFF
--- a/Tests/Fixtures/app/AppKernel.php
+++ b/Tests/Fixtures/app/AppKernel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bazinga\Bundle\JsTranslationBundle\Tests;
+namespace Bazinga\Bundle\JsTranslationBundle\Tests\Fixtures\app;
 
 // get the autoload file
 $dir = __DIR__;

--- a/Tests/WebTestCase.php
+++ b/Tests/WebTestCase.php
@@ -5,6 +5,7 @@ namespace Bazinga\Bundle\JsTranslationBundle\Tests;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel;
+use Bazinga\Bundle\JsTranslationBundle\Tests\Fixtures\app\AppKernel;
 
 abstract class WebTestCase extends BaseWebTestCase
 {
@@ -30,9 +31,7 @@ abstract class WebTestCase extends BaseWebTestCase
 
     protected static function getKernelClass()
     {
-        require_once __DIR__.'/Fixtures/app/AppKernel.php';
-
-        return 'Bazinga\Bundle\JsTranslationBundle\Tests\AppKernel';
+        return AppKernel::class;
     }
 
     protected static function createKernel(array $options = array())


### PR DESCRIPTION
```
Deprecation Notice: Class Bazinga\Bundle\JsTranslationBundle\Tests\AppKernel located in vendor/willdurand/js-translation-bundle\Tests\Fixtures\app\AppKernel.php does not comply with psr-4 autoloading standard. It will not autoload any
more in Composer v2.0. in phar://composer.phar/src/Composer/Autoload/ClassMapGenerator.php:185
```