### PR TITLE
Exclude tests and development files from the archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/.travis.yml      export-ignore
+/Tests            export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
This also avoids a deprecation notice from composer when generating an optimized autoloader due to the fixture app of the tests not following the PSR-4 convention configured for sources (while being in a subfolder)