### PR TITLE
dump output to `public/js` instead of `web/js` directory.

### DIFF
--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -86,7 +86,7 @@ class DumpCommand extends Command
     {
         parent::initialize($input, $output);
 
-        $this->targetPath = $input->getArgument('target') ?: sprintf('%s/../web/js', $this->kernelRootDir);
+        $this->targetPath = $input->getArgument('target') ?: sprintf('%s/../public/js', $this->kernelRootDir);
     }
 
     /**
@@ -112,7 +112,7 @@ class DumpCommand extends Command
         ));
 
         $this->dumper->dump($this->targetPath, $input->getOption('pattern'), $formats, $merge);
-        
+
         return 0;
     }
 }


### PR DESCRIPTION
As of Symfony 4, the default public web directory has been renamed from `web` to `public`.
Dump the files there by default (the [docs](https://github.com/willdurand/BazingaJsTranslationBundle/blob/master/Resources/doc/index.md#the-dump-command) already say so).


