### PR TITLE
Fixes deprecation of referencing controllers with single colon

### DIFF
--- a/Resources/config/routing/routing.yml
+++ b/Resources/config/routing/routing.yml
@@ -1,6 +1,9 @@
 bazinga_jstranslation_js:
     path:  /translations/{domain}.{_format}
-    defaults: { _controller: bazinga.jstranslation.controller:getTranslationsAction, domain: "messages", _format: "js" }
+    defaults:
+        _controller: bazinga.jstranslation.controller::getTranslationsAction
+        domain: "messages"
+        _format: "js"
     methods:  [ GET ]
     options:
         i18n: false


### PR DESCRIPTION
Fixes this deprecation message thrown in Symfony 5.1:
`User Deprecated: Since symfony/http-kernel 5.1: Referencing controllers with a single colon is deprecated. Use "bazinga.jstranslation.controller::getTranslationsAction" instead.`