### PR TITLE
Allow domain like ```messages+icu-intl``` in routing.yml

### DIFF
--- a/Resources/config/routing/routing.yml
+++ b/Resources/config/routing/routing.yml
@@ -7,4 +7,5 @@ bazinga_jstranslation_js:
         expose: true
     requirements:
         _format: js|json
-        domain: "[\\w]+"
+        domain: "[\\w+-]+"
+


### PR DESCRIPTION
Allow domain to contain + and - for «+icu-intl» suffixes, when using the symfony on-the-fly generated translation.