### PR TITLE
Remove support for Symfony < 3.3 constructor signature

### DIFF
--- a/DependencyInjection/Compiler/TranslationResourceFilesPass.php
+++ b/DependencyInjection/Compiler/TranslationResourceFilesPass.php
@@ -49,14 +49,9 @@ class TranslationResourceFilesPass implements CompilerPassInterface
         $translationFiles = array();
         $translator = $container->findDefinition('translator.default');
 
-        try {
-            $translatorOptions = $translator->getArgument(4);
-        } catch (OutOfBoundsException $e) {
-            $translatorOptions = array();
-        }
 
-        $translatorOptions = array_merge($translatorOptions, $translator->getArgument(3));
-        
+        $translatorOptions = $translator->getArgument(4);
+
         if (isset($translatorOptions['resource_files'])) {
             $translationFiles = $translatorOptions['resource_files'];
         }


### PR DESCRIPTION
This bundle dropped support for Symfony <= 3.3 in #271, so the compiler pass doesn't need to cater for the old Symfony translator signature, and can just use the new signature from 3.3+.

Fixes #291 
Replaces #293 