### PR TITLE
Update TranslationResourceFilesPass.php

### DIFF
--- a/DependencyInjection/Compiler/TranslationResourceFilesPass.php
+++ b/DependencyInjection/Compiler/TranslationResourceFilesPass.php
@@ -48,14 +48,7 @@ class TranslationResourceFilesPass implements CompilerPassInterface
     {
         $translationFiles = array();
         $translator = $container->findDefinition('translator.default');
-
-        try {
-            $translatorOptions = $translator->getArgument(4);
-        } catch (OutOfBoundsException $e) {
-            $translatorOptions = array();
-        }
-
-        $translatorOptions = array_merge($translatorOptions, $translator->getArgument(3));
+        $translatorOptions = $translator->getArgument(4);
         
         if (isset($translatorOptions['resource_files'])) {
             $translationFiles = $translatorOptions['resource_files'];


### PR DESCRIPTION
remove support for Symfony <3.3 in argument index.

refs #201

fix #291