### PR TITLE
Fix multiple files translations for same domain

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -138,7 +138,10 @@ class Controller
 
                 foreach ($files as $filename) {
                     [$currentDomain] = Util::extractCatalogueInformationFromFilename($filename);
-                    $translations[$locale][$currentDomain] = array();
+
+                    if (!isset($translations[$locale][$currentDomain])) {
+                        $translations[$locale][$currentDomain] = array();
+                    }
 
                     $extension = pathinfo($filename, \PATHINFO_EXTENSION);
 


### PR DESCRIPTION
This fixes a bug introduced in 43a51cf1fa2adc4c7bb985af8c9ebc414eea04a0.

The issue is translations are overridden for every file: a same domain cannot have translations loaded from several files anymore.

By checking if the array is already set, this behavior is fixed.