### PR TITLE
escaping XML/HTML tags according to intl-messageformat documentation

### DIFF
--- a/Resources/js/translator.js
+++ b/Resources/js/translator.js
@@ -132,8 +132,10 @@
                 if (typeof IntlMessageFormat === 'undefined') {
                     throw new Error('The dependency "IntlMessageFormat" is required to use ICU MessageFormat but it has not been found. Please read https://github.com/willdurand/BazingaJsTranslationBundle/blob/master/Resources/doc/index.md#using-icu-messageformat')
                 }
-
-                var mf = new IntlMessageFormat.IntlMessageFormat(_message);
+                
+                //escaping XML/HTML tags according to intl-messageformat documentation
+                //https://formatjs.io/docs/intl-messageformat/
+                var mf = new IntlMessageFormat.IntlMessageFormat(_message.replace(/(<\/?[^>]+>)/gi, "'$1'"));
 
                 return mf.format(parameters || {});
             }

--- a/Resources/js/translator.js
+++ b/Resources/js/translator.js
@@ -304,6 +304,10 @@
             _additionalReturn.isICU = true;
             return _messages[_locale][_domain + INTL_DOMAIN_SUFFIX][id];
         }
+        
+        if (_domain.indexOf(INTL_DOMAIN_SUFFIX) !== -1) {
+            _additionalReturn.isICU = true;
+        }
 
         if (has_message(_locale, _domain, id)) {
             return _messages[_locale][_domain][id];


### PR DESCRIPTION
support translation ids like
translation.id:
  {count, plural,
    one {<b>1</b> item}
    other {<b>{count}</b> items}
  }