### PR TITLE
Fix :  When domain is not defined, get_message find translations in intl-icu format but don't format it correctly

### DIFF
--- a/Resources/js/translator.js
+++ b/Resources/js/translator.js
@@ -291,7 +291,7 @@
                 if (has_message(_locale, _domains[i], id) ||
                     has_message(nationalLocaleFallback, _domains[i], id) ||
                     has_message(localeFallback, _domains[i], id)) {
-                    _domain = _domains[i];
+                    _domain = _domains[i].replace(INTL_DOMAIN_SUFFIX, '');
 
                     break;
                 }

--- a/Resources/js/translatorTest.js
+++ b/Resources/js/translatorTest.js
@@ -21,7 +21,7 @@ test('add()', function() {
 });
 
 test('trans()', function() {
-    expect(14);
+    expect(17);
 
     Translator.add('foo', 'bar', 'Foo');
     Translator.add('foo.with.arg', 'This is Ba %arg%');
@@ -57,6 +57,11 @@ test('trans()', function() {
     equal(Translator.trans('messages.with.args', { name: 'John', projectCount: 0 }, 'messages'), 'John has no projects.', 'Returns the ICU-formatted message with correct replaces.');
     equal(Translator.trans('messages.with.args', { name: 'John', projectCount: 1 }, 'messages'), 'John has 1 project.', 'Returns the ICU-formatted message with correct replaces.');
     equal(Translator.trans('messages.with.args', { name: 'John', projectCount: 4 }, 'messages'), 'John has 4 projects.', 'Returns the ICU-formatted message with correct replaces.');
+
+    equal(Translator.trans('messages.with.args', { name: 'John', projectCount: 0 }), 'John has no projects.', 'Returns the ICU-formatted message with correct replaces.');
+    equal(Translator.trans('messages.with.args', { name: 'John', projectCount: 1 }), 'John has 1 project.', 'Returns the ICU-formatted message with correct replaces.');
+    equal(Translator.trans('messages.with.args', { name: 'John', projectCount: 4 }), 'John has 4 projects.', 'Returns the ICU-formatted message with correct replaces.');
+
 });
 
 test('transChoice()', function() {


### PR DESCRIPTION
Given the following translations file:

`# translations/messages+intl-icu.en.yaml
 hello_name: Hello {name}!`

When domain is not defined, get_message find the translation in intl-icu format, but it don't format it correctly.

`Translator.trans('hello_name', { name: 'John' })`

give

`Hello {name}!`

it should give

`Hello John!`