### PR TITLE
Update getTranslations.js.twig

### DIFF
--- a/Resources/views/getTranslations.js.twig
+++ b/Resources/views/getTranslations.js.twig
@@ -4,10 +4,10 @@ t.fallback = '{{ fallback }}';
 t.defaultDomain = '{{ defaultDomain }}';
 {% endif %}
 {% for locale, domains in translations %}
-// {{ locale }}
+// {{ locale|raw }}
 {% for domain, messages in domains %}
 {% for key, message in messages %}
-t.add({{ key|json_encode|raw }}, {{ message|json_encode|raw }}, "{{ domain }}", "{{ locale }}");
+t.add({{ key|json_encode|raw }}, {{ message|json_encode|raw }}, "{{ domain }}", "{{ locale|raw }}");
 {% endfor %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
The filter "raw" is necessary to encode language with subtags in javascript file, otherwise there is an error on locale code ("en\u002DUS" for example).