### PR TITLE
Prevent translation files overwriting files from addResource calls

### DIFF
--- a/DependencyInjection/Compiler/TranslationResourceFilesPass.php
+++ b/DependencyInjection/Compiler/TranslationResourceFilesPass.php
@@ -18,7 +18,7 @@ class TranslationResourceFilesPass implements CompilerPassInterface
         }
 
         $translationFiles = $this->getTranslationFilesFromAddResourceCalls($container);
-        $translationFiles = array_merge($translationFiles, $this->getTranslationFiles($container));
+        $translationFiles = array_merge_recursive($translationFiles, $this->getTranslationFiles($container));
 
         $container->getDefinition('bazinga.jstranslation.translation_finder')->replaceArgument(0, $translationFiles);
     }


### PR DESCRIPTION
array_merge with replace the translations that are in there while array_merge_recursive will append them. That way you don't loose translation sources.