### PR TITLE
Fix: Change own KernelTestCase class to use the new method signature

### DIFF
--- a/Tests/WebTestCase.php
+++ b/Tests/WebTestCase.php
@@ -3,6 +3,7 @@
 namespace Bazinga\Bundle\JsTranslationBundle\Tests;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel;
 use Bazinga\Bundle\JsTranslationBundle\Tests\Fixtures\app\AppKernel;
@@ -19,10 +20,10 @@ abstract class WebTestCase extends BaseWebTestCase
         $fs->remove($dir);
     }
 
-    protected function getContainer(array $options = array())
+    protected static function getContainer(): ContainerInterface
     {
         if (!static::$kernel) {
-            static::$kernel = static::createKernel($options);
+            static::$kernel = static::createKernel();
         }
         static::$kernel->boot();
 


### PR DESCRIPTION
PHP Fatal error:  Cannot make static method Symfony\Bundle\FrameworkBundle\Test\KernelTestCase::getContainer() non static in class Bazinga\Bundle\JsTranslationBundle\Tests\WebTestCase in /home/runner/work/BazingaJsTranslationBundle/BazingaJsTranslationBundle/Tests/WebTestCase.php on line 10