### PR TITLE
TranslationDumper consider now <domain>+intl-icu and <domain> as the same domain

### DIFF
--- a/Dumper/TranslationDumper.php
+++ b/Dumper/TranslationDumper.php
@@ -266,17 +266,17 @@ class TranslationDumper
                 $translations[$locale] = array();
             }
 
-            if (!isset($translations[$locale][$domain])) {
-                $translations[$locale][$domain] = array();
+            if (!isset($translations[$locale][$domainCleaned])) {
+                $translations[$locale][$domainCleaned] = array();
             }
 
             if (isset($this->loaders[$extension])) {
                 $catalogue = $this->loaders[$extension]
-                    ->load($filename, $locale, $domain);
+                    ->load($filename, $locale, $domainCleaned);
 
-                $translations[$locale][$domain] = array_replace_recursive(
-                    $translations[$locale][$domain],
-                    $catalogue->all($domain)
+                $translations[$locale][$domainCleaned] = array_replace_recursive(
+                    $translations[$locale][$domainCleaned],
+                    $catalogue->all($domainCleaned)
                 );
             }
         }

--- a/Tests/Dumper/TranslationDumperTest.php
+++ b/Tests/Dumper/TranslationDumperTest.php
@@ -59,7 +59,7 @@ JS;
     const JS_FR_MERGED_TRANSLATIONS = <<<JS
 (function (t) {
 // fr
-t.add("hello_name", "bonjour {name} !", "messages\u002Bintl\u002Dicu", "fr");
+t.add("hello_name", "bonjour {name} !", "messages", "fr");
 t.add("hello", "bonjour", "messages", "fr");
 t.add(7, "Nos occasions", "numerics", "fr");
 t.add(8, "Nous contacter", "numerics", "fr");
@@ -74,7 +74,7 @@ JS;
     const JS_FR_MESSAGES_TRANSLATIONS = <<<JS
 (function (t) {
 // fr
-t.add("hello_name", "bonjour {name} !", "messages\u002Bintl\u002Dicu", "fr");
+t.add("hello_name", "bonjour {name} !", "messages", "fr");
 t.add("hello", "bonjour", "messages", "fr");
 })(Translator);
 
@@ -124,14 +124,14 @@ JSON;
 
     const JSON_FR_MERGED_TRANSLATIONS = <<<JSON
 {
-    "translations": {"fr":{"messages+intl-icu":{"hello_name":"bonjour {name} !"},"messages":{"hello":"bonjour"},"numerics":{"7":"Nos occasions","8":"Nous contacter","12":"pr\u00e9nom","13":"nom","14":"adresse","15":"code postal"}}}
+    "translations": {"fr":{"messages":{"hello_name":"bonjour {name} !","hello":"bonjour"},"numerics":{"7":"Nos occasions","8":"Nous contacter","12":"pr\u00e9nom","13":"nom","14":"adresse","15":"code postal"}}}
 }
 
 JSON;
 
     const JSON_FR_MESSAGES_TRANSLATIONS = <<<JSON
 {
-    "translations": {"fr":{"messages+intl-icu":{"hello_name":"bonjour {name} !"},"messages":{"hello":"bonjour"}}}
+    "translations": {"fr":{"messages":{"hello_name":"bonjour {name} !","hello":"bonjour"}}}
 }
 
 JSON;


### PR DESCRIPTION
Actually `TranslationDumper::getTranslations()` called from `DumpCommand` consider `<domain>+intl-icu` and `<domain>` as two different domains.
I think that should not be the case.
Context: i have some `<domain>.<lang>.xlf` mixed to `<domain>+intl-icu.<lang>.xlf` due to removing transChoice to upgrade symfony version from 3.4 to 4.4 so no more transChoice and welcome intl-icu.
Maybe related to issue #312 ?
(First PR for me :) )
