### PR TITLE
Fix french pluralization

### DIFF
--- a/Resources/js/translator.js
+++ b/Resources/js/translator.js
@@ -550,6 +550,8 @@
             case 'bh':
             case 'fil':
             case 'fr':
+                return number % 1000000 === 0 ? 1 : (number < 2 ? 0 : 2);
+
             case 'gun':
             case 'hi':
             case 'ln':


### PR DESCRIPTION
References:
- https://github.com/willdurand/BazingaJsTranslationBundle/issues/334
- https://unicode-org.github.io/cldr-staging/charts/38/supplemental/language_plural_rules.html#rules

Accommodate the “new” plural form for French. The form itself isn’t new to the language, it just hasn’t been used on the Internet until recently. The Unicode Consortium (the organization which sets standards for software internationalization) made the change in the rules and recommends supporting this added plural form. 

```xml
<source>{0} 0 days|{1} 1 day|]1,Inf] %1$s% days</source>
<target state="final">%1$s% jour| %1$s% de jours| %1$s% jours</target>
```

The second form `de` is only for numbers above `1000000`.
