### PR TITLE
[WIP] fix: ensure fallback locale is always loaded

### DIFF
--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -210,6 +210,10 @@ class Controller
             return trim($locale);
         }, $locales));
 
+		if ($this->localeFallback && !in_array($this->localeFallback, $locales)) {
+			$locales[] = $this->localeFallback;
+		}
+
         return $locales;
     }
 }

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -442,6 +442,9 @@ bazinga_js_translation:
                          # translator fallback.
 ```
 
+When a fallback locale is defined, that locale's translations will always
+be loaded.
+
 #### Default Domain
 
 You can define the default domain used when translation messages are added


### PR DESCRIPTION
In the current version, when a fallback locale is defined, it isn't loaded automatically (as explained in #307). 

That means you still have to specifically request that the fallback be loaded, which is inconvenient and often forgotten.

This commit updates the `getLocales()` method to ensure the fallback translations are always loaded when a fallback locale is defined.

Here's a comparison in the case of a project with the `fr_CA` as the default locale and `fr` as the fallback locale (with only one message, in order to keep things simple).

**Before:**
```js
(function (t) {
t.fallback = 'fr';
t.defaultDomain = 'messages';
// fr_CA
})(Translator);
```

**After:**
```js
(function (t) {
t.fallback = 'fr';
t.defaultDomain = 'messages';
// fr_CA
// fr
t.add("generic.save", "Enregistrer", "messages", "fr");
})(Translator);
```

Closes #307