### PR TITLE
Fix deprecations of Symfony 6.3

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,8 @@ env:
 jobs:
     test:
         name: PHP ${{ matrix.php-version }} + Symfony ${{ matrix.symfony-version }}
-        runs-on: 'ubuntu-latest'
+        # TODO find a different setup for the JS testsuite as phantomjs is abandoned and is not available on newer runner images
+        runs-on: 'ubuntu-20.04'
         continue-on-error: ${{ matrix.allowed-to-fail }}
 
         strategy:

--- a/BazingaJsTranslationBundle.php
+++ b/BazingaJsTranslationBundle.php
@@ -12,6 +12,9 @@ use Bazinga\Bundle\JsTranslationBundle\DependencyInjection\Compiler\AddLoadersPa
  */
 class BazingaJsTranslationBundle extends Bundle
 {
+    /**
+     * @return void
+     */
     public function build(ContainerBuilder $container)
     {
         parent::build($container);

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -32,7 +32,7 @@ class DumpCommand extends Command
 
     /**
      * @param TranslationDumper $dumper
-     * @param $kernelRootDir
+     * @param string $kernelRootDir
      */
     public function __construct(TranslationDumper $dumper, $projectDir)
     {
@@ -43,7 +43,7 @@ class DumpCommand extends Command
     }
 
     /**
-     * {@inheritDoc}
+     * @return void
      */
     protected function configure()
     {
@@ -80,7 +80,7 @@ class DumpCommand extends Command
     }
 
     /**
-     * {@inheritDoc}
+     * @return void
      */
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
@@ -112,7 +112,7 @@ class DumpCommand extends Command
         ));
 
         $this->dumper->dump($this->targetPath, $input->getOption('pattern'), $formats, $merge);
-        
+
         return 0;
     }
 }

--- a/DependencyInjection/BazingaJsTranslationExtension.php
+++ b/DependencyInjection/BazingaJsTranslationExtension.php
@@ -16,6 +16,8 @@ class BazingaJsTranslationExtension extends Extension
 {
     /**
      * Load configuration.
+     *
+     * @return void
      */
     public function load(array $configs, ContainerBuilder $container)
     {

--- a/DependencyInjection/Compiler/AddLoadersPass.php
+++ b/DependencyInjection/Compiler/AddLoadersPass.php
@@ -11,6 +11,9 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class AddLoadersPass implements CompilerPassInterface
 {
+    /**
+     * @return void
+     */
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition('bazinga.jstranslation.controller')) {

--- a/DependencyInjection/Compiler/TranslationResourceFilesPass.php
+++ b/DependencyInjection/Compiler/TranslationResourceFilesPass.php
@@ -11,6 +11,9 @@ use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
  */
 class TranslationResourceFilesPass implements CompilerPassInterface
 {
+    /**
+     * @return void
+     */
     public function process(ContainerBuilder $container)
     {
         if (!$container->has('translator.default')) {

--- a/Tests/Fixtures/app/AppKernel.php
+++ b/Tests/Fixtures/app/AppKernel.php
@@ -64,12 +64,12 @@ class AppKernel extends Kernel
         return sys_get_temp_dir().'/'.Kernel::VERSION.'/bazinga-js-translation/logs';
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__.'/config/'.$this->environment.'.yml');
         $loader->load(__DIR__.'/config/base_config.yml');
         $loader->load(__DIR__.'/config/disable_annotations.yml');
-        
+
         if (self::VERSION_ID < 40200 && file_exists(__DIR__.'/Resources/translations') === false) {
             self::recurseCopy(__DIR__.'/../translations', __DIR__.'/Resources/translations');
         }

--- a/Tests/Fixtures/app/TestingPurposesBundle/DependencyInjection/Compiler/GetTranslationWithMethodCallsFromDefinition.php
+++ b/Tests/Fixtures/app/TestingPurposesBundle/DependencyInjection/Compiler/GetTranslationWithMethodCallsFromDefinition.php
@@ -11,7 +11,7 @@ use Symfony\Component\Finder\Finder;
  */
 class GetTranslationWithMethodCallsFromDefinition implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $translationFile = __DIR__ .'/../../Resources/translations/bar.en.yml';
         $translator = $container->findDefinition('translator.default');

--- a/Tests/Fixtures/app/TestingPurposesBundle/TestingPurposesBundle.php
+++ b/Tests/Fixtures/app/TestingPurposesBundle/TestingPurposesBundle.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class TestingPurposesBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/Tests/Fixtures/app/TestingPurposesBundle/TestingPurposesExtension.php
+++ b/Tests/Fixtures/app/TestingPurposesBundle/TestingPurposesExtension.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class TestingPurposesExtension extends Extension
 {
-    public function load(array $config, ContainerBuilder $container)
+    public function load(array $config, ContainerBuilder $container): void
     {
     }
 }


### PR DESCRIPTION
This uses `@return` to opt-out of the deprecation, as done for a bunch of existing ones coming from older Symfony version.

Note that you will need to do a major version (as those classes are neither final nor internal) before being able to support Symfony 7.