### PR TITLE
Add support for Symfony 7

### DIFF
--- a/BazingaJsTranslationBundle.php
+++ b/BazingaJsTranslationBundle.php
@@ -9,13 +9,12 @@ use Bazinga\Bundle\JsTranslationBundle\DependencyInjection\Compiler\AddLoadersPa
 
 /**
  * @author William DURAND <william.durand1@gmail.com>
+ *
+ * @final
  */
 class BazingaJsTranslationBundle extends Bundle
 {
-    /**
-     * @return void
-     */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -12,6 +12,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @author Adrien Russo <adrien.russo.qc@gmail.com>
  * @author Hugo Monteiro <hugo.monteiro@gmail.com>
+ *
+ * @final
  */
 class DumpCommand extends Command
 {
@@ -42,10 +44,7 @@ class DumpCommand extends Command
         parent::__construct();
     }
 
-    /**
-     * @return void
-     */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('bazinga:js-translation:dump')
@@ -79,20 +78,14 @@ class DumpCommand extends Command
             );
     }
 
-    /**
-     * @return void
-     */
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
 
         $this->targetPath = $input->getArgument('target') ?: sprintf('%s/../web/js', $this->kernelRootDir);
     }
 
-    /**
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $formats = $input->getOption('format');
         $merge = (object) array(

--- a/Controller/Controller.php
+++ b/Controller/Controller.php
@@ -17,6 +17,8 @@ use Twig\Loader\LoaderInterface;
 
 /**
  * @author William DURAND <william.durand1@gmail.com>
+ *
+ * @final
  */
 class Controller
 {

--- a/DependencyInjection/BazingaJsTranslationExtension.php
+++ b/DependencyInjection/BazingaJsTranslationExtension.php
@@ -11,15 +11,12 @@ use Symfony\Component\Config\Definition\Processor;
 /**
  * @author William DURAND <william.durand1@gmail.com>
  * @author Hugo Monteiro <hugo.monteiro@gmail.com>
+ *
+ * @final
  */
 class BazingaJsTranslationExtension extends Extension
 {
-    /**
-     * Load configuration.
-     *
-     * @return void
-     */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $processor     = new Processor();
         $configuration = new Configuration($container->getParameter('kernel.debug'));

--- a/DependencyInjection/Compiler/AddLoadersPass.php
+++ b/DependencyInjection/Compiler/AddLoadersPass.php
@@ -8,13 +8,12 @@ use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author William DURAND <william.durand1@gmail.com>
+ *
+ * @internal
  */
 class AddLoadersPass implements CompilerPassInterface
 {
-    /**
-     * @return void
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('bazinga.jstranslation.controller')) {
             return;

--- a/DependencyInjection/Compiler/TranslationResourceFilesPass.php
+++ b/DependencyInjection/Compiler/TranslationResourceFilesPass.php
@@ -8,13 +8,12 @@ use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 
 /**
  * @author Hugo MONTEIRO <hugo.monteiro@gmail.com>
+ *
+ * @internal
  */
 class TranslationResourceFilesPass implements CompilerPassInterface
 {
-    /**
-     * @return void
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has('translator.default')) {
             return;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -7,15 +7,12 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
  * @author William DURAND <william.durand1@gmail.com>
+ *
+ * @final
  */
 class Configuration implements ConfigurationInterface
 {
-    /**
-     * Generates the configuration tree builder.
-     *
-     * @return TreeBuilder The tree builder
-     */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('bazinga_js_translation');
 

--- a/Dumper/TranslationDumper.php
+++ b/Dumper/TranslationDumper.php
@@ -11,6 +11,8 @@ use Twig\Environment;
 /**
  * @author Adrien Russo <adrien.russo.qc@gmail.com>
  * @author Hugo Monteiro <hugo.monteiro@gmail.com>
+ *
+ * @internal
  */
 class TranslationDumper
 {

--- a/Finder/TranslationFinder.php
+++ b/Finder/TranslationFinder.php
@@ -8,6 +8,8 @@ use Bazinga\Bundle\JsTranslationBundle\Util;
  * @author William DURAND <william.durand1@gmail.com>
  * @author Markus Poerschke <markus@eluceo.de>
  * @author Hugo MONTEIRO <hugo.monteiro@gmail.com>
+ *
+ * @internal
  */
 class TranslationFinder
 {

--- a/composer.json
+++ b/composer.json
@@ -12,20 +12,19 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "symfony/framework-bundle": "~4.4|~5.0|~6.0",
-        "symfony/finder": "~4.4|~5.0|~6.0",
-        "symfony/console": "~4.4|~5.0|~6.0",
-        "symfony/intl": "~4.4|~5.0|~6.0",
-        "symfony/translation":  "~4.4|~5.0|~6.0",
-        "symfony/twig-bundle": "~4.4|~5.0|~6.0"
+        "symfony/framework-bundle": "~4.4|~5.0|~6.0|~7.0",
+        "symfony/finder": "~4.4|~5.0|~6.0|~7.0",
+        "symfony/console": "~4.4|~5.0|~6.0|~7.0",
+        "symfony/intl": "~4.4|~5.0|~6.0|~7.0",
+        "symfony/translation":  "~4.4|~5.0|~6.0|~7.0",
+        "symfony/twig-bundle": "~4.4|~5.0|~6.0|~7.0"
     },
     "require-dev": {
-        "symfony/asset": "~4.4|~5.0|~6.0",
-        "symfony/filesystem": "~4.4|~5.0|~6.0",
-        "symfony/yaml": "~4.4|~5.0|~6.0",
-        "symfony/browser-kit": "~4.4|~5.0|~6.0",
-        "symfony/twig-bundle": "~4.4|~5.0|~6.0",
-        "symfony/phpunit-bridge": "^5.0|^6.0",
+        "symfony/asset": "~4.4|~5.0|~6.0|~7.0",
+        "symfony/filesystem": "~4.4|~5.0|~6.0|~7.0",
+        "symfony/yaml": "~4.4|~5.0|~6.0|~7.0",
+        "symfony/browser-kit": "~4.4|~5.0|~6.0|~7.0",
+        "symfony/phpunit-bridge": "^5.0|^6.0|~7.0",
         "phpunit/phpunit": "^4.8|~5.7|~6.5|~8"
     },
     "replace": {
@@ -36,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.7-dev"
+            "dev-master": "3.x-dev"
         }
     }
 }


### PR DESCRIPTION
Closes #347 

Due to the requirement to add the native return type in the Configuration class and the DumpCommand class which were neither final nor internal, this should be released as a new major version to respect semver.
All the `void` return type I'm adding as native return types are actually optional in Symfony 7. They will become required only in Symfony 8. As adding them also requires a major version, I'm adding them at the same time (so that Symfony 8 does not require a new bump of the major version).

I also took the opportunity to mark classes as `@final` or `@internal` to reduce the BC API of the bundle for the future. Note that for now, the command and controller are only marked as `@final` but I'm wondering whether they could be marked as `@internal` instead if they are only meant to be initialized by the service definition of this bundle.