### PR TITLE
Fix the branch alias for the master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.x-dev"
+            "dev-master": "6.x-dev"
         }
     }
 }


### PR DESCRIPTION
In #348, I bumped the branch alias for a new major version. But it was actually far outdated. This bumps it to the actual next major version.