### PR TITLE
Use the UMD build of intl-messageformat in the testsuite

### DIFF
--- a/Resources/js/index-with-es5-shim.html
+++ b/Resources/js/index-with-es5-shim.html
@@ -7,7 +7,7 @@
         <script src="libs/es5-shim.js"></script>
         <script src="libs/qunit/qunit.js"></script>
         <script src="https://polyfill.io/v3/polyfill.min.js?features=Intl,Intl.~locale.fr,Intl.PluralRules.~locale.fr,Intl.PluralRules,Number.isFinite"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/intl-messageformat/9.0.2/intl-messageformat.min.js"></script>
+        <script src="https://unpkg.com/intl-messageformat@9.0.2/dist/umd/intl-messageformat.min.js"></script>
         <script src="translator.js"></script>
         <script src="translatorTest.js"></script>
         <link rel="stylesheet" href="./libs/qunit/qunit.css">

--- a/Resources/js/index.html
+++ b/Resources/js/index.html
@@ -6,7 +6,7 @@
         <script src="libs/jquery-1.6.1.min.js"></script>
         <script src="libs/qunit/qunit.js"></script>
         <script src="https://polyfill.io/v3/polyfill.min.js?features=Intl,Intl.~locale.fr,Intl.PluralRules.~locale.fr,Intl.PluralRules,Number.isFinite"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/intl-messageformat/9.0.2/intl-messageformat.min.js"></script>
+        <script src="https://unpkg.com/intl-messageformat@9.0.2/dist/umd/intl-messageformat.min.js"></script>
         <script src="translator.js"></script>
         <script src="translatorTest.js"></script>
         <link rel="stylesheet" href="./libs/qunit/qunit.css">


### PR DESCRIPTION
The main file of the library is a CommonJS build, not an UMD build, making it incompatible with the usage in the testsuite setup. The UMD build is shipped in the package but is not exposed on CDNJS.