### PR TITLE
Fix the loading of the Intl JS polyfills

### DIFF
--- a/Resources/js/index-with-es5-shim.html
+++ b/Resources/js/index-with-es5-shim.html
@@ -6,7 +6,7 @@
         <script src="libs/jquery-1.6.1.min.js"></script>
         <script src="libs/es5-shim.js"></script>
         <script src="libs/qunit/qunit.js"></script>
-        <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=Intl,Intl.~locale.fr,Intl.PluralRules.~locale.fr,Intl.PluralRules,Number.isFinite"></script>
+        <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0&features=Intl.DateTimeFormat,Intl.NumberFormat,Intl.PluralRules,Number.isFinite"></script>
         <script src="https://unpkg.com/intl-messageformat@9.0.2/dist/umd/intl-messageformat.min.js"></script>
         <script src="translator.js"></script>
         <script src="translatorTest.js"></script>

--- a/Resources/js/index.html
+++ b/Resources/js/index.html
@@ -5,7 +5,7 @@
         <title>ExposeTranslationBundle Unit Tests</title>
         <script src="libs/jquery-1.6.1.min.js"></script>
         <script src="libs/qunit/qunit.js"></script>
-        <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=Intl,Intl.~locale.fr,Intl.PluralRules.~locale.fr,Intl.PluralRules,Number.isFinite"></script>
+        <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0&features=Intl.DateTimeFormat,Intl.NumberFormat,Intl.PluralRules,Number.isFinite"></script>
         <script src="https://unpkg.com/intl-messageformat@9.0.2/dist/umd/intl-messageformat.min.js"></script>
         <script src="translator.js"></script>
         <script src="translatorTest.js"></script>


### PR DESCRIPTION
The Intl polyfill has been split into dedicated polyfills in 2020.
As the Cloudflare service allows to specify a version of the polyfill-library, the version is now locked to avoid being affected by such change again.