### PR TITLE
Clean the CI setup

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,27 +19,16 @@ jobs:
         continue-on-error: ${{ matrix.allowed-to-fail }}
 
         strategy:
+            fail-fast: false
             matrix:
-                php-version: ['7.4', '8.0', '8.1']
-                variant: [normal]
+                php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
                 dependencies: [highest]
-                allowed-to-fail: [true]
+                allowed-to-fail: [false]
                 symfony-version: [latest]
                 include:
-                  - php-version: '7.4'
+                  - php-version: nightly
                     dependencies: highest
-                    variant: normal
-                    allowed-to-fail: false
-                    symfony-version: latest
-                  - php-version: '8.0'
-                    dependencies: highest
-                    variant: normal
-                    allowed-to-fail: false
-                    symfony-version: latest
-                  - php-version: '8.1'
-                    dependencies: highest
-                    variant: normal
-                    allowed-to-fail: false
+                    allowed-to-fail: true
                     symfony-version: latest
         steps:
             - name: "Checkout code"
@@ -53,16 +42,8 @@ jobs:
                   tools: composer:v2
                   extensions: intl, xdebug
 
-            - name: "Set composer cache directory"
-              id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-            - name: Install variant
-              if: matrix.variant != 'normal'
-              run: composer require ${{ matrix.variant }} --no-update
-
             - name: "Install Composer dependencies (${{ matrix.dependencies }})"
-              uses: "ramsey/composer-install@v1"
+              uses: "ramsey/composer-install@v3"
               with:
                 dependency-versions: "${{ matrix.dependencies }}"
                 composer-options: "--prefer-dist"

--- a/Dumper/TranslationDumper.php
+++ b/Dumper/TranslationDumper.php
@@ -118,13 +118,13 @@ class TranslationDumper
      * @param string $target Target directory.
      * @param string $pattern route path
      * @param string[] $formats Formats to generate.
-     * @param \stdClass $merge Merge options.
+     * @param \stdClass|null $merge Merge options.
      */
     public function dump(
         $target = 'web/js',
         $pattern = self::DEFAULT_TRANSLATION_PATTERN,
         array $formats = array(),
-        \stdClass $merge = null
+        ?\stdClass $merge = null
     ) {
         $availableFormats  = array('js', 'json');
 


### PR DESCRIPTION
- Remove jobs allowed to fail for stable PHP versions (keeping only jobs that requires passing, making that the default)
- Add CI jobs for PHP 8.2, 8.3 and 8.4
- Add an experimental (i.e. allowed to fail) job for PHP nightly
- Remove the `variant` from the matrix as it is always `normal`
- Remove the step fetching the composer cache location as this location is never used
- Upgrade the `ramsey/composer-install` action to avoid deprecation warnings
- ensure we don't cancel jobs for other PHP versions when one fails, to make it easier to determine whether a failure is version-specific.