### PR TITLE
Wrong dump directory in documentation

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -199,7 +199,7 @@ This bundle provides a command to dump the translation files:
     php bin/console bazinga:js-translation:dump [target] [--format=js|json] [--pattern=/translations/{domain}.{_format}] [--merge-domains]
 
 The optional `target` argument allows you to override the target directory to
-dump JS translation files in. By default, it generates files in the `public/js/`
+dump JS translation files in. By default, it generates files in the `web/js/`
 directory.
 
 The `--format` option allows you to specify which formats must be included in the output.


### PR DESCRIPTION
See https://github.com/willdurand/BazingaJsTranslationBundle/blob/28283525bed4071d6d827af1402318ecf29d156e/Command/DumpCommand.php#L85