### PR TITLE
Improve the npm package metadata

### DIFF
--- a/Resources/package.json
+++ b/Resources/package.json
@@ -7,6 +7,10 @@
     "symfony"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/willdurand/BazingaJsTranslationBundle.git"
+  },
   "author": {
     "name": "William Durand",
     "email": "will+git@drnd.me"
@@ -17,11 +21,23 @@
       "email": "bens.sampaio@gmail.com"
     }
   ],
+  "bugs": {
+    "url": "https://github.com/willdurand/BazingaJsTranslationBundle/issues"
+  },
+  "homepage": "https://github.com/willdurand/BazingaJsTranslationBundle",
   "files": [
     "js/translator.js",
     "public/js/translator.min.js"
   ],
   "main": "js/translator.js",
+  "peerDependencies": {
+    "intl-messageformat": "^10.5.14"
+  },
+  "peerDependenciesMeta": {
+    "intl-messageformat": {
+      "optional": false
+    }
+  },
   "devDependencies": {
     "@web/test-runner": "^0.18.2",
     "intl-messageformat": "^10.5.14",


### PR DESCRIPTION
- add metadata that allows npmjs.com to link back to the repository
- add an optional peer dependency on `intl-messageformat` so that tools being strict about dependency access (pnpm, Yarn PnP mode) can be supported (relates to https://github.com/willdurand/BazingaJsTranslationBundle/issues/336)

To make the package even better, it might make sense to create a `README.md`, as npmjs.com will render it.

Regarding the `intl-messageformat`, I'm actually wondering whether it should be defined as a required dependency instead (and then probably a normal dependency, not a peer one) as the way the UMD wrapper is defined does not make it optional when using CommonJS or RequireJS (the `require()` is always done):
https://github.com/willdurand/BazingaJsTranslationBundle/blob/6fbd01ddc4c73957e6776aa0ca1ba32e20ca889b/Resources/js/translator.js#L5-L18